### PR TITLE
Disabled checking for license headers in md and sh files

### DIFF
--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -14,6 +14,10 @@
 /**
  * The lists of the license we accept.
  */
+license {
+    excludePatterns = ['**/*.md', '**/*.sh'] as Set
+}
+
 ext.acceptedLicenses = [
     'BSD License',
     'BSD 2-Clause',


### PR DESCRIPTION
Simply adding exclusion pattern to md and sh files for license checks.