### PR TITLE
When receiving invalid Handshake packet the session should be dropped

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -32,12 +32,17 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
   private final Pipeline outgoingPipeline;
   private final Scheduler scheduler;
   private final NodeRecordFactory nodeRecordFactory;
+  private final NodeSessionManager nodeSessionManager;
 
   public HandshakeMessagePacketHandler(
-      Pipeline outgoingPipeline, Scheduler scheduler, NodeRecordFactory nodeRecordFactory) {
+      Pipeline outgoingPipeline,
+      Scheduler scheduler,
+      NodeRecordFactory nodeRecordFactory,
+      NodeSessionManager nodeSessionManager) {
     this.outgoingPipeline = outgoingPipeline;
     this.scheduler = scheduler;
     this.nodeRecordFactory = nodeRecordFactory;
+    this.nodeSessionManager = nodeSessionManager;
   }
 
   @Override
@@ -147,5 +152,6 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
   private void markHandshakeAsFailed(final Envelope envelope, final NodeSession session) {
     envelope.remove(Field.PACKET_HANDSHAKE);
     session.cancelAllRequests("Failed to handshake");
+    nodeSessionManager.dropSession(session);
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
@@ -3,8 +3,8 @@
  */
 package org.ethereum.beacon.discovery;
 
+import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class DiscoveryManagerTest {
   public static final String LOCALHOST = "127.0.0.1";
-  public static final Duration RETRY_TIMEOUT = Duration.ofSeconds(30);
-  public static final Duration LIVE_CHECK_INTERVAL = Duration.ofSeconds(30);
+  public static final Duration RETRY_TIMEOUT = ofSeconds(30);
+  public static final Duration LIVE_CHECK_INTERVAL = ofSeconds(30);
 
   @Test
   public void testRegularHandshake() throws Exception {
@@ -112,7 +112,7 @@ public class DiscoveryManagerTest {
 
     // victim node should drop the session on the first malformed handshake message
     // and ignore any subsequent handshake messages
-    assertThatThrownBy(victimNode::nextOutbound);
+    assertThat(victimNode.maybeNextOutbound(ofSeconds(1))).isEmpty();
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
@@ -4,13 +4,25 @@
 package org.ethereum.beacon.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.TestManagerWrapper.TestMessage;
+import org.ethereum.beacon.discovery.message.PingMessage;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
+import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket.HandshakeAuthData;
+import org.ethereum.beacon.discovery.packet.Header;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
+import org.ethereum.beacon.discovery.packet.RawPacket;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.schema.NodeSession;
+import org.ethereum.beacon.discovery.type.Bytes16;
+import org.ethereum.beacon.discovery.util.Functions;
 import org.junit.jupiter.api.Test;
 
 public class DiscoveryManagerTest {
@@ -43,6 +55,65 @@ public class DiscoveryManagerTest {
     m1.deliver(out2_2); // Pong
 
     assertThat(pingRes).isCompleted();
+  }
+
+  @Test
+  public void testInvalidHandshakeShouldDropsSession() throws Exception {
+    TestNetwork network = new TestNetwork();
+    TestManagerWrapper attackerNode = network.createDiscoveryManager(1);
+    TestManagerWrapper victimNode = network.createDiscoveryManager(2);
+
+    CompletableFuture<Void> pingRes =
+        attackerNode.getDiscoveryManager().ping(victimNode.getNodeRecord());
+
+    TestMessage out1_1 = attackerNode.nextOutbound();
+    assertThat(out1_1.getPacket()).isInstanceOf(OrdinaryMessagePacket.class);
+    victimNode.deliver(out1_1); // Random (Ping is pending)
+
+    TestMessage out2_1 = victimNode.nextOutbound();
+    assertThat(out2_1.getPacket()).isInstanceOf(WhoAreYouPacket.class);
+    attackerNode.deliver(out2_1); // WhoAreYou
+
+    TestMessage validHandshakeMessage = attackerNode.nextOutbound(); // valid Handshake
+    assertThat(validHandshakeMessage.getPacket()).isInstanceOf(HandshakeMessagePacket.class);
+
+    // preparing Handshake with invalid id signature
+    NodeSession attackerToVictimSession =
+        attackerNode
+            .getDiscoveryManager()
+            .getNodeSession(victimNode.getNodeRecord().getNodeId())
+            .orElseThrow();
+    HandshakeMessagePacket handshakePacket =
+        (HandshakeMessagePacket) validHandshakeMessage.getPacket();
+    RawPacket handshakeRawPacket = validHandshakeMessage.getRawPacket();
+    Header<HandshakeAuthData> header = handshakePacket.getHeader();
+    Bytes invalidSignature = Functions.sign(attackerNode.getPrivateKey(), Bytes32.ZERO);
+    Header<HandshakeAuthData> malformedHeader =
+        Header.createHandshakeHeader(
+            header.getAuthData().getSourceNodeId(),
+            header.getStaticHeader().getNonce(),
+            invalidSignature,
+            header.getAuthData().getEphemeralPubKey(),
+            header.getAuthData().getNodeRecord(NodeRecordFactory.DEFAULT));
+    HandshakeMessagePacket malformedHandshakePacket =
+        HandshakeMessagePacket.create(
+            handshakeRawPacket.getMaskingIV(),
+            malformedHeader,
+            new PingMessage(Bytes.EMPTY, UInt64.ONE),
+            attackerToVictimSession.getInitiatorKey());
+    Bytes16 maskingKey = Bytes16.wrap(victimNode.getNodeRecord().getNodeId(), 0);
+    RawPacket malformedRawPacket =
+        RawPacket.createAndMask(
+            handshakeRawPacket.getMaskingIV(), malformedHandshakePacket, maskingKey);
+    TestMessage malformedMessage = attackerNode.createOutbound(malformedRawPacket, victimNode);
+
+    victimNode.deliver(malformedMessage); // Malformed Handshake
+    victimNode.deliver(malformedMessage); // Malformed Handshake
+    victimNode.deliver(validHandshakeMessage);
+
+    // victim node should drop the session on the first malformed handshake message
+    // and ignore any subsequent handshake messages
+    assertThatThrownBy(victimNode::nextOutbound);
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
@@ -63,8 +63,7 @@ public class DiscoveryManagerTest {
     TestManagerWrapper attackerNode = network.createDiscoveryManager(1);
     TestManagerWrapper victimNode = network.createDiscoveryManager(2);
 
-    CompletableFuture<Void> pingRes =
-        attackerNode.getDiscoveryManager().ping(victimNode.getNodeRecord());
+    attackerNode.getDiscoveryManager().ping(victimNode.getNodeRecord());
 
     TestMessage out1_1 = attackerNode.nextOutbound();
     assertThat(out1_1.getPacket()).isInstanceOf(OrdinaryMessagePacket.class);

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +49,7 @@ import org.ethereum.beacon.discovery.pipeline.PipelineImpl;
 import org.ethereum.beacon.discovery.pipeline.handler.HandshakeMessagePacketHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.MessageHandler;
 import org.ethereum.beacon.discovery.pipeline.handler.MessagePacketHandler;
+import org.ethereum.beacon.discovery.pipeline.handler.NodeSessionManager;
 import org.ethereum.beacon.discovery.pipeline.handler.WhoAreYouPacketHandler;
 import org.ethereum.beacon.discovery.pipeline.info.FindNodeResponseHandler;
 import org.ethereum.beacon.discovery.pipeline.info.MultiPacketResponseHandler;
@@ -175,7 +177,10 @@ public class HandshakeHandlersTest {
     // Node2 handle AuthHeaderPacket and finish handshake
     HandshakeMessagePacketHandler handshakeMessagePacketHandlerNode2 =
         new HandshakeMessagePacketHandler(
-            outgoingPipeline, taskScheduler, NODE_RECORD_FACTORY_NO_VERIFICATION);
+            outgoingPipeline,
+            taskScheduler,
+            NODE_RECORD_FACTORY_NO_VERIFICATION,
+            mock(NodeSessionManager.class));
     Envelope envelopeAt2From1 = new Envelope();
     RawPacket handshakeRawPacket = outgoing1Packets.poll(1, TimeUnit.SECONDS);
     envelopeAt2From1.put(

--- a/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
+++ b/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
@@ -105,7 +105,7 @@ public class TestManagerWrapper {
 
   public Optional<TestMessage> maybeNextOutbound(Duration timeout) {
     try {
-      return Optional.ofNullable(outbound.poll(timeout.toMillis(), TimeUnit.SECONDS))
+      return Optional.ofNullable(outbound.poll(timeout.toMillis(), TimeUnit.MILLISECONDS))
           .map(parcel -> new TestMessage(getNodeRecord(), parcel));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
+++ b/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryServer;
 import org.ethereum.beacon.discovery.network.NetworkParcel;
+import org.ethereum.beacon.discovery.network.NetworkParcelV5;
 import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.packet.RawPacket;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
@@ -62,15 +63,19 @@ public class TestManagerWrapper {
 
   private final TestNetwork testNetwork;
   private final DiscoveryManagerImpl discoveryManager;
+  private final ECKeyPair keyPair;
   private final BlockingQueue<NetworkParcel> outbound = new LinkedBlockingQueue<>();
 
   public static TestManagerWrapper create(TestNetwork testNetwork, int seed) {
-    return new TestManagerWrapper(testNetwork, createTestManager(seed));
+    ECKeyPair keyPair = Functions.generateECKeyPair(new Random(seed));
+    return new TestManagerWrapper(testNetwork, createTestManager(keyPair, 9000 + seed), keyPair);
   }
 
-  private TestManagerWrapper(TestNetwork testNetwork, DiscoveryManagerImpl discoveryManager) {
+  private TestManagerWrapper(
+      TestNetwork testNetwork, DiscoveryManagerImpl discoveryManager, ECKeyPair keyPair) {
     this.testNetwork = testNetwork;
     this.discoveryManager = discoveryManager;
+    this.keyPair = keyPair;
     Flux.from(discoveryManager.getOutgoingMessages()).subscribe(outbound::add);
   }
 
@@ -122,13 +127,23 @@ public class TestManagerWrapper {
     return ret;
   }
 
-  private static DiscoveryManagerImpl createTestManager(int seed) {
-    ECKeyPair keyPair = Functions.generateECKeyPair(new Random(seed));
-    final Bytes privateKey =
-        Bytes.wrap(Utils.extractBytesFromUnsignedBigInt(keyPair.getPrivateKey(), PRIVKEY_SIZE));
+  public Bytes getPrivateKey() {
+    return toPrivateKey(keyPair);
+  }
 
+  public TestMessage createOutbound(RawPacket packet, TestManagerWrapper to) {
+    return new TestMessage(
+        getNodeRecord(), new NetworkParcelV5(packet, to.getNodeRecord().getUdpAddress().get()));
+  }
+
+  private static Bytes toPrivateKey(ECKeyPair keyPair) {
+    return Bytes.wrap(Utils.extractBytesFromUnsignedBigInt(keyPair.getPrivateKey(), PRIVKEY_SIZE));
+  }
+
+  private static DiscoveryManagerImpl createTestManager(ECKeyPair keyPair, int port) {
+    final Bytes privateKey = toPrivateKey(keyPair);
     final NodeRecord nodeRecord =
-        new NodeRecordBuilder().privateKey(privateKey).address(LOCALHOST, 9000 + seed).build();
+        new NodeRecordBuilder().privateKey(privateKey).address(LOCALHOST, port).build();
     DiscoverySystemBuilder builder = new DiscoverySystemBuilder();
     builder
         .discoveryServer(Mockito.mock(NettyDiscoveryServer.class))

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
@@ -31,7 +31,7 @@ import org.ethereum.beacon.discovery.storage.NonceRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-class NodeIdToSessionTest {
+class NodeSessionManagerTest {
 
   private static final Bytes STATIC_NODE_KEY = Bytes.fromHexString("0x1234");
   public static final Bytes NODE_ID = Bytes.fromHexString("0x888888");
@@ -44,8 +44,8 @@ class NodeIdToSessionTest {
   private final NodeTable nodeTable = mock(NodeTable.class);
   private final Pipeline outgoingPipeline = mock(Pipeline.class);
 
-  private final NodeIdToSession handler =
-      new NodeIdToSession(
+  private final NodeSessionManager handler =
+      new NodeSessionManager(
           new LocalNodeRecordStore(
               homeNodeRecord, homeNodeInfo.getPrivateKey(), NodeRecordListener.NOOP),
           STATIC_NODE_KEY,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

When receiving invalid Handshake packet the session should be dropped I.e. another negotiation round (Random, WhoAreYou) needs to be performed.
Else the peer could be DoSed with a single invalid Handshake packet forcing to perform expensive `BLS` signature validation for free from attacker side 

## Fixed Issue(s)

When merged https://github.com/ConsenSys/teku/issues/2846