### PR TITLE
Switch to tag based releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,3 +68,5 @@ workflows:
       - publish:
           requires:
             - build
+          context:
+            - quorum-gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,9 @@ workflows:
   circleci:
     jobs:
       - build:
+          filters:
+            tags: &filters-release-tags
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
           context:
             - dockerhub-quorumengineering-ro
       - publish:
@@ -76,6 +79,8 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+            tags:
+              <<: *filters-release-tags
           requires:
             - build
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ executors:
   medium_executor:
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
+        auth:
+          username: $DOCKER_USER_RO
+          password: $DOCKER_PASSWORD_RO
     resource_class: medium
     working_directory: ~/project
     environment:
@@ -64,9 +67,17 @@ workflows:
   version: 2
   circleci:
     jobs:
-      - build
+      - build:
+          context:
+            - dockerhub-quorumengineering-ro
       - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
           requires:
             - build
           context:
             - quorum-gradle
+            - dockerhub-quorumengineering-ro

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Publish
           command: |
-            ./gradlew --no-daemon --parallel bintrayUpload
+            ./gradlew --no-daemon --parallel publish
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,5 @@ workflows:
     jobs:
       - build
       - publish:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
-                - cloudsmith
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,5 +71,6 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+                - cloudsmith
           requires:
             - build

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 plugins {
   id 'java-library'
   id 'com.diffplug.gradle.spotless' version '3.26.0'
-  id 'com.jfrog.bintray' version '1.8.4'
   id 'com.github.ben-manes.versions' version '0.27.0'
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
@@ -152,11 +151,22 @@ task runTestDiscovery(type:JavaExec) {
 }
 
 def resolvedVersion = calculateVersion()
-def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
+
+def cloudsmithUser = project.hasProperty('cloudsmithUser') ? project.property('cloudsmithUser') : System.getenv('CLOUDSMITH_USER')
+def cloudsmithKey = project.hasProperty('cloudsmithApiKey') ? project.property('cloudsmithApiKey') : System.getenv('CLOUDSMITH_API_KEY')
 
 apply plugin: 'maven-publish'
 publishing {
+  repositories {
+    maven {
+      name = "cloudsmith"
+      url = "https://api-g.cloudsmith.io/maven/consensys/maven/"
+      credentials {
+        username = cloudsmithUser
+        password = cloudsmithKey
+      }
+    }
+  }
   publications {
     mavenJava(MavenPublication) {
       groupId "tech.pegasys.discovery"
@@ -183,32 +193,6 @@ publishing {
           url = 'https://github.com/PegaSysEng/discovery'
         }
       }
-    }
-  }
-}
-
-bintray {
-  user = bintrayUser
-  key = bintrayKey
-
-  publications = ['mavenJava']
-  override = version.endsWith('SNAPSHOT')
-
-  publish = true
-
-  pkg {
-    repo = 'pegasys-repo'
-    name = 'discovery'
-    userOrg = 'consensys'
-    desc = 'Java implementation of discovery v5'
-    licenses = ['Apache-2.0']
-    websiteUrl = 'https://github.com/PegaSysEng/discovery'
-    issueTrackerUrl = 'https://github.com/PegaSysEng/discovery/issues'
-    vcsUrl = 'https://github.com/PegaSysEng/discovery.git'
-
-    version {
-      name = resolvedVersion
-      released = new Date()
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,12 @@ plugins {
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
   id 'net.ltgt.errorprone' version '1.1.1'
+  id 'org.ajoberstar.grgit' version '4.0.2'
 }
+
+rootProject.version = calculatePublishVersion()
+def specificVersion = calculateVersion()
+def isDevelopBuild = rootProject.version.contains('develop')
 
 apply from: "${rootDir}/gradle/versions.gradle"
 apply from: "${rootDir}/gradle/check-licenses.gradle"
@@ -26,7 +31,6 @@ dependencies {
   implementation 'org.apache.tuweni:units'
   implementation 'org.apache.tuweni:crypto'
   implementation 'org.bouncycastle:bcprov-jdk15on'
-//  implementation 'org.miracl.milagro.amcl:milagro-crypto-java'
 
   implementation 'com.google.guava:guava'
   implementation 'io.projectreactor:reactor-core'
@@ -116,7 +120,7 @@ tasks.withType(JavaCompile) {
           'Specification-Title': project.name,
           'Specification-Version': project.version,
           'Implementation-Title': project.name,
-          'Implementation-Version': calculateVersion()
+          'Implementation-Version': specificVersion
       )
     }
   }
@@ -150,8 +154,6 @@ task runTestDiscovery(type:JavaExec) {
     systemProperty "log4j.configurationFile", "log4j2-test-discovery.xml"
 }
 
-def resolvedVersion = calculateVersion()
-
 def cloudsmithUser = project.hasProperty('cloudsmithUser') ? project.property('cloudsmithUser') : System.getenv('CLOUDSMITH_USER')
 def cloudsmithKey = project.hasProperty('cloudsmithApiKey') ? project.property('cloudsmithApiKey') : System.getenv('CLOUDSMITH_API_KEY')
 
@@ -170,7 +172,7 @@ publishing {
   publications {
     mavenJava(MavenPublication) {
       groupId "tech.pegasys.discovery"
-      version resolvedVersion
+      version project.version
       from components.java
       artifact sourcesJar
 
@@ -180,7 +182,7 @@ publishing {
       }
       pom {
         name = "${project.name}"
-        url = 'http://github.com/PegaSysEng/discovery'
+        url = 'http://github.com/ConsenSys/discovery'
         licenses {
           license {
             name = 'The Apache License, Version 2.0'
@@ -188,43 +190,56 @@ publishing {
           }
         }
         scm {
-          connection = 'scm:git:git://github.com/PegaSysEng/discovery.git'
-          developerConnection = 'scm:git:ssh://github.com/PegaSysEng/discovery.git'
-          url = 'https://github.com/PegaSysEng/discovery'
+          connection = 'scm:git:git://github.com/ConsenSys/discovery.git'
+          developerConnection = 'scm:git:ssh://github.com/ConsenSys/discovery.git'
+          url = 'https://github.com/ConsenSys/discovery'
         }
       }
     }
   }
 }
 
-// Takes the version, and if -SNAPSHOT is part of it replaces SNAPSHOT
-// with the git commit version.
+
+// Calculate the version that this build would be published under (if it is published)
+// If this exact commit is tagged, use the tag
+// If this is on a release-* branch, use the most recent tag appended with +develop (e.g. 0.1.1-RC1+develop)
+// Otherwise, use develop
+def calculatePublishVersion() {
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  def specificVersion = calculateVersion()
+  def isReleaseBranch = grgit.branch.current().name.startsWith('release-')
+  if (specificVersion.contains('+')) {
+    return isReleaseBranch ? "${specificVersion.substring(0, specificVersion.indexOf('+'))}+develop" : "develop"
+  }
+  return specificVersion
+}
+
+// Calculate the version that teku --version will report (among other places)
+// If this exact commit is tagged, use the tag
+// Otherwise use git describe --tags and replace the - after the tag with a +
 def calculateVersion() {
-  String version = rootProject.version
-  if (version.endsWith("-SNAPSHOT")) {
-    version = version.replace("-SNAPSHOT", "-dev-" + getCheckedOutGitCommitHash())
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  String version = grgit.describe(tags: true)
+  def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
+  def matcher = version =~ versionPattern
+  if (matcher.find()) {
+    return "${matcher.group("lastVersion")}+${matcher.group("devVersion")}"
   }
   return version
 }
 
-def getCheckedOutGitCommitHash() {
-  def gitFolder = "$projectDir/.git/"
-  if (!file(gitFolder).isDirectory()) {
-    // We are in a submodule.  The file's contents are `gitdir: <gitFolder>\n`.
-    // Read the file, cut off the front, and trim the whitespace.
-    gitFolder = file(gitFolder).text.substring(8).trim() + "/"
+task printVersion() {
+  doFirst {
+    print "Specific version: ${specificVersion}  Publish version: ${project.version}"
   }
+}
+
+
+def getCheckedOutGitCommitHash() {
   def takeFromHash = 8
-  /*
-   * '.git/HEAD' contains either
-   *      in case of detached head: the currently checked out commit hash
-   *      otherwise: a reference to a file containing the current commit hash
-   */
-  def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
-  def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
-
-  if (isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
-
-  def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
-  refHead.text.trim().take takeFromHash
+  grgit ? grgit.head().id.take(takeFromHash) : 'UNKNOWN'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-version=0.4.3-SNAPSHOT


### PR DESCRIPTION
## PR Description
Switch over to tag based releases.  Besu is using this library now so its getting more updates and the "release every commit" approach we had been using doesn't play well with HyperLedger.  So to avoid having too many versions published to the repo and still make releases really easy, switch to tag based releases.

Builds on #90 