### PR TITLE
Added NodeRecordFactory.fromEnr method

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
@@ -63,7 +63,7 @@ public class NodeRecordFactory {
   }
 
   public NodeRecord fromEnr(String enr) {
-    return fromBase64(enr.substring("enr:".length()));
+    return fromBase64(enr.startsWith("enr:") ? enr.substring("enr:".length()) : enr);
   }
 
   public NodeRecord fromBytes(Bytes bytes) {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
@@ -62,6 +62,10 @@ public class NodeRecordFactory {
     return fromBytes(Base64.getUrlDecoder().decode(enrBase64));
   }
 
+  public NodeRecord fromEnr(String enr) {
+    return fromBase64(enr.substring("enr:".length()));
+  }
+
   public NodeRecord fromBytes(Bytes bytes) {
     return fromBytes(bytes.toArray());
   }

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -188,6 +188,17 @@ public class NodeRecordTest {
   }
 
   @Test
+  public void shouldDecodeEnr_WithOrWithoutPrefix() {
+    final NodeRecordFactory nodeRecordFactory =
+        new NodeRecordFactory(new IdentitySchemaV4Interpreter());
+    final String base64 =
+        "-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+    final NodeRecord nodeRecordWithoutPrefix = nodeRecordFactory.fromEnr(base64);
+    final NodeRecord nodeRecordWithPrefix = nodeRecordFactory.fromEnr("enr:" + base64);
+    assertEquals(nodeRecordWithoutPrefix, nodeRecordWithPrefix);
+  }
+
+  @Test
   public void testEnrWithEthFieldDecodes() {
     final int port = 30303;
     final Bytes ip = Bytes.fromHexString("0x7F000001");

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -174,8 +174,8 @@ public class NodeRecordTest {
     final NodeRecordFactory nodeRecordFactory =
         new NodeRecordFactory(new IdentitySchemaV4Interpreter());
     final NodeRecord nodeRecord =
-        nodeRecordFactory.fromBase64(
-            "-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8");
+        nodeRecordFactory.fromEnr(
+            "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8");
     final Bytes nodeId =
         Bytes.fromHexString("a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7");
     assertEquals(nodeId, nodeRecord.getNodeId());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description
Added a new method, `NodeRecordFactory.fromEnr(String enr)`, that automatically handles the enr: prefix.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #99 
