### PR TITLE
Remove docker hub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,6 @@ executors:
   medium_executor:
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
-        auth:
-          username: $DOCKER_USER_RO
-          password: $DOCKER_PASSWORD_RO
     resource_class: medium
     working_directory: ~/project
     environment:
@@ -71,8 +68,6 @@ workflows:
           filters:
             tags: &filters-release-tags
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
-          context:
-            - dockerhub-quorumengineering-ro
       - publish:
           filters:
             branches:
@@ -85,4 +80,3 @@ workflows:
             - build
           context:
             - cloudsmith-protocols
-            - dockerhub-quorumengineering-ro


### PR DESCRIPTION
## PR Description
So that builds work for external contributors, remove the docker hub credentials and context.  Downloads of docker images may wind up being throttled but given the short build times and infrequent changes that's unlikely to be an issue for this project.