### PR TITLE
Include our seq no in PONG messages, not remote peer's

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/PingHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/PingHandler.java
@@ -14,7 +14,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
 public class PingHandler implements MessageHandler<PingMessage> {
   @Override
   public void handle(PingMessage message, NodeSession session) {
-    final NodeRecord nodeRecord = session.getNodeRecord().orElseThrow();
+    final NodeRecord nodeRecord = session.getHomeNodeRecord();
     final InetSocketAddress remoteAddress = session.getRemoteAddress();
     PongMessage responseMessage =
         new PongMessage(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -6,7 +6,7 @@ package org.ethereum.beacon.discovery.pipeline.info;
 import org.ethereum.beacon.discovery.message.NodesMessage;
 
 public class FindNodeResponseHandler implements MultiPacketResponseHandler<NodesMessage> {
-  private static final int MAX_TOTAL_PACKETS = 5;
+  private static final int MAX_TOTAL_PACKETS = 16;
   private int totalPackets = -1;
   private int receivedPackets = 0;
 

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
@@ -1,0 +1,46 @@
+package org.ethereum.beacon.discovery.message.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
+import org.ethereum.beacon.discovery.message.PingMessage;
+import org.ethereum.beacon.discovery.message.PongMessage;
+import org.ethereum.beacon.discovery.schema.NodeSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PingHandlerTest {
+
+  private final PingHandler handler = new PingHandler();
+
+  private final InetSocketAddress REMOTE_ADDRESS = new InetSocketAddress("localhost", 25234);
+  private final NodeSession session = mock(NodeSession.class);
+  private final NodeInfo localNode = TestUtil.generateNode(9000);
+
+  @BeforeEach
+  void setUp() {
+    when(session.getHomeNodeRecord()).thenReturn(localNode.getNodeRecord());
+    when(session.getRemoteAddress()).thenReturn(REMOTE_ADDRESS);
+  }
+
+  @Test
+  void shouldRespondWithOurSequenceNumberAndRemoteAddressInfo() {
+    final Bytes requestId = Bytes.fromHexString("0x4678");
+    final PingMessage message = new PingMessage(requestId, UInt64.valueOf(3));
+    handler.handle(message, session);
+
+    verify(session)
+        .sendOutgoingOrdinary(
+            new PongMessage(
+                requestId,
+                localNode.getNodeRecord().getSeq(),
+                Bytes.wrap(REMOTE_ADDRESS.getAddress().getAddress()),
+                REMOTE_ADDRESS.getPort()));
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.ethereum.beacon.discovery.message.handler;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
## PR Description
When responding to PING messages, the PONG response should include our local ENR sequence number, not the remote peers.

This enables remote peers to detect when they need to request an updated ENR from us.