### PR TITLE
Get latest home enr

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -142,14 +142,15 @@ public class DiscoverySystemBuilder {
             discoveryServer,
             () -> new NettyDiscoveryServerImpl(serverListenAddress, trafficReadLimit));
 
-    nodeBucketStorage =
-        requireNonNullElseGet(nodeBucketStorage, () -> new NodeBucketStorageImpl(localNodeRecord));
     localNodeRecordStore =
         requireNonNullElseGet(
             localNodeRecordStore,
             () ->
                 new LocalNodeRecordStore(
                     localNodeRecord, privateKey, localNodeRecordListener, newAddressHandler));
+    nodeBucketStorage =
+        requireNonNullElseGet(
+            nodeBucketStorage, () -> new NodeBucketStorageImpl(localNodeRecordStore));
     nodeTableStorage =
         requireNonNullElseGet(
             nodeTableStorage, () -> nodeTableStorageFactory.createTable(bootnodes));

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.message.FindNodeMessage;
 import org.ethereum.beacon.discovery.message.NodesMessage;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
-import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 
 public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
@@ -46,7 +45,6 @@ public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
             .distinct()
             .flatMap(session::getNodeRecordsInBucket)
             .limit(MAX_TOTAL_NODES_PER_RESPONSE)
-            .map(NodeRecordInfo::getNode)
             .collect(Collectors.toList());
 
     List<List<NodeRecord>> nodeRecordBatches =

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
@@ -44,8 +44,7 @@ public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
     List<NodeRecord> nodeRecordInfos =
         message.getDistances().stream()
             .distinct()
-            .flatMap(d -> session.getBucket(d).stream())
-            .flatMap(b -> b.getNodeRecords().stream())
+            .flatMap(session::getNodeRecordsInBucket)
             .limit(MAX_TOTAL_NODES_PER_RESPONSE)
             .map(NodeRecordInfo::getNode)
             .collect(Collectors.toList());

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -342,7 +342,7 @@ public class NodeSession {
     nodeBucketStorage.put(nodeRecordInfo);
   }
 
-  public Stream<NodeRecordInfo> getNodeRecordsInBucket(int index) {
+  public Stream<NodeRecord> getNodeRecordsInBucket(int index) {
     return nodeBucketStorage.getNodeRecords(index);
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -37,7 +38,6 @@ import org.ethereum.beacon.discovery.pipeline.info.Request;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
 import org.ethereum.beacon.discovery.scheduler.ExpirationScheduler;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
-import org.ethereum.beacon.discovery.storage.NodeBucket;
 import org.ethereum.beacon.discovery.storage.NodeBucketStorage;
 import org.ethereum.beacon.discovery.storage.NodeTable;
 import org.ethereum.beacon.discovery.type.Bytes12;
@@ -342,8 +342,8 @@ public class NodeSession {
     nodeBucketStorage.put(nodeRecordInfo);
   }
 
-  public Optional<NodeBucket> getBucket(int index) {
-    return nodeBucketStorage.get(index);
+  public Stream<NodeRecordInfo> getNodeRecordsInBucket(int index) {
+    return nodeBucketStorage.getNodeRecords(index);
   }
 
   public synchronized Bytes getIdNonce() {

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorage.java
@@ -4,12 +4,12 @@
 
 package org.ethereum.beacon.discovery.storage;
 
-import java.util.Optional;
+import java.util.stream.Stream;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 
 /** Stores {@link NodeRecordInfo}'s in {@link NodeBucket}'s */
 public interface NodeBucketStorage {
-  Optional<NodeBucket> get(int index);
+  Stream<NodeRecordInfo> getNodeRecords(int index);
 
   void put(NodeRecordInfo nodeRecordInfo);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorage.java
@@ -5,11 +5,12 @@
 package org.ethereum.beacon.discovery.storage;
 
 import java.util.stream.Stream;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 
 /** Stores {@link NodeRecordInfo}'s in {@link NodeBucket}'s */
 public interface NodeBucketStorage {
-  Stream<NodeRecordInfo> getNodeRecords(int index);
+  Stream<NodeRecord> getNodeRecords(int index);
 
   void put(NodeRecordInfo nodeRecordInfo);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorageImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucketStorageImpl.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery.storage;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.database.HoleyList;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
@@ -30,9 +31,13 @@ public class NodeBucketStorageImpl implements NodeBucketStorage {
     nodeBucketsTable.put(0, zero);
   }
 
-  @Override
-  public Optional<NodeBucket> get(int index) {
+  private Optional<NodeBucket> get(int index) {
     return nodeBucketsTable.get(index);
+  }
+
+  @Override
+  public Stream<NodeRecordInfo> getNodeRecords(final int index) {
+    return get(index).stream().flatMap(bucket -> bucket.getNodeRecords().stream());
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactory.java
@@ -19,5 +19,5 @@ public interface NodeTableStorageFactory {
    */
   NodeTableStorage createTable(List<NodeRecord> bootnodes);
 
-  NodeBucketStorage createBucketStorage(NodeRecord homeNode);
+  NodeBucketStorage createBucketStorage(LocalNodeRecordStore localNodeRecordStore);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactoryImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeTableStorageFactoryImpl.java
@@ -35,7 +35,7 @@ public class NodeTableStorageFactoryImpl implements NodeTableStorageFactory {
   }
 
   @Override
-  public NodeBucketStorage createBucketStorage(NodeRecord homeNode) {
-    return new NodeBucketStorageImpl(homeNode);
+  public NodeBucketStorage createBucketStorage(LocalNodeRecordStore localNodeRecordStore) {
+    return new NodeBucketStorageImpl(localNodeRecordStore);
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -114,6 +114,6 @@ public class DiscoveryInteropTest {
     // 1 sent findnodes to 2, received only (2) in answer
     // 1 added 2 to its nodeBuckets, because its now checked, but not before
     assertThat(nodeBucketStorage1.getNodeRecords(distance1To2).map(NodeRecord::getNodeId))
-        .containsExactlyInAnyOrder(nodeRecord2.getNodeId());
+        .containsExactly(nodeRecord2.getNodeId());
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryInteropTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryServerImpl;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
@@ -55,7 +56,10 @@ public class DiscoveryInteropTest {
             "-IS4QHa5-0-OmPRchyyBf9jHIWnQlZXthveUPp5_DoDnMMB0V9ChlzNq_fhFixvIr8xOQcKrYsWjjeIBoUIS8HSuWbgBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMOLLdCQcDE_I6BZvGnmgXVsN2VgTp0sJRSnzF9XDnSNYN1ZHCCdl8"); // Geth node
     NodeTableStorageFactoryImpl nodeTableStorageFactory = new NodeTableStorageFactoryImpl();
     NodeTableStorage nodeTableStorage1 = nodeTableStorageFactory.createTable(List.of(nodeRecord2));
-    NodeBucketStorage nodeBucketStorage1 = nodeTableStorageFactory.createBucketStorage(nodeRecord1);
+    NodeBucketStorage nodeBucketStorage1 =
+        nodeTableStorageFactory.createBucketStorage(
+            new LocalNodeRecordStore(
+                nodeRecord1, Bytes.EMPTY, NodeRecordListener.NOOP, NewAddressHandler.NOOP));
     DiscoveryManagerImpl discoveryManager1 =
         new DiscoveryManagerImpl(
             new NettyDiscoveryServerImpl(
@@ -109,10 +113,7 @@ public class DiscoveryInteropTest {
     Thread.sleep(1000);
     // 1 sent findnodes to 2, received only (2) in answer
     // 1 added 2 to its nodeBuckets, because its now checked, but not before
-    assertThat(
-            nodeBucketStorage1
-                .getNodeRecords(distance1To2)
-                .map(record -> record.getNode().getNodeId()))
+    assertThat(nodeBucketStorage1.getNodeRecords(distance1To2).map(NodeRecord::getNodeId))
         .containsExactlyInAnyOrder(nodeRecord2.getNodeId());
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -5,16 +5,16 @@
 package org.ethereum.beacon.discovery;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.ethereum.beacon.discovery.TestUtil.NODE_RECORD_FACTORY_NO_VERIFICATION;
 import static org.ethereum.beacon.discovery.TestUtil.TEST_TRAFFIC_READ_LIMIT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryServerImpl;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
@@ -23,9 +23,9 @@ import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
 import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Schedulers;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.ethereum.beacon.discovery.storage.NewAddressHandler;
-import org.ethereum.beacon.discovery.storage.NodeBucket;
 import org.ethereum.beacon.discovery.storage.NodeBucketStorage;
 import org.ethereum.beacon.discovery.storage.NodeRecordListener;
 import org.ethereum.beacon.discovery.storage.NodeTableStorage;
@@ -134,16 +134,15 @@ public class DiscoveryNetworkTest {
     assertTrue(randomSent1to2.await(1, TimeUnit.SECONDS));
     assertTrue(whoareyouSent2to1.await(1, TimeUnit.SECONDS));
     int distance1To2 = Functions.logDistance(nodeRecord1.getNodeId(), nodeRecord2.getNodeId());
-    assertFalse(nodeBucketStorage1.get(distance1To2).isPresent());
+    assertThat(nodeBucketStorage1.getNodeRecords(distance1To2)).isEmpty();
     assertTrue(authPacketSent1to2.await(1, TimeUnit.SECONDS));
     assertTrue(nodesSent2to1.await(1, TimeUnit.SECONDS));
     Thread.sleep(50);
     // 1 sent findnodes to 2, received only (2) in answer, because 3 is not checked
     // 1 added 2 to its nodeBuckets, because its now checked, but not before
-    NodeBucket bucketAt1With2 = nodeBucketStorage1.get(distance1To2).get();
-    assertEquals(1, bucketAt1With2.size());
-    assertEquals(
-        nodeRecord2.getNodeId(), bucketAt1With2.getNodeRecords().get(0).getNode().getNodeId());
+    Stream<NodeRecordInfo> nodesInBucketAt1With2 = nodeBucketStorage1.getNodeRecords(distance1To2);
+    assertThat(nodesInBucketAt1With2.map(record -> record.getNode().getNodeId()))
+        .containsExactlyInAnyOrder(nodeRecord2.getNodeId());
   }
 
   // TODO: discovery tasks are emitted from time to time as they should

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -146,7 +146,7 @@ public class DiscoveryNetworkTest {
     // 1 added 2 to its nodeBuckets, because its now checked, but not before
     Stream<NodeRecord> nodesInBucketAt1With2 = nodeBucketStorage1.getNodeRecords(distance1To2);
     assertThat(nodesInBucketAt1With2.map(NodeRecord::getNodeId))
-        .containsExactlyInAnyOrder(nodeRecord2.getNodeId());
+        .containsExactly(nodeRecord2.getNodeId());
   }
 
   // TODO: discovery tasks are emitted from time to time as they should

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -84,10 +84,20 @@ public class HandshakeHandlersTest {
     NodeInfo nodePair2 = TestUtil.generateUnverifiedNode(30304);
     NodeRecord nodeRecord2 = nodePair2.getNodeRecord();
     NodeTableStorageFactoryImpl nodeTableStorageFactory = new NodeTableStorageFactoryImpl();
+    final LocalNodeRecordStore localNodeRecordStoreAt1 =
+        new LocalNodeRecordStore(
+            nodeRecord1,
+            nodePair1.getPrivateKey(),
+            NodeRecordListener.NOOP,
+            NewAddressHandler.NOOP);
     NodeTableStorage nodeTableStorage1 = nodeTableStorageFactory.createTable(List.of(nodeRecord2));
-    NodeBucketStorage nodeBucketStorage1 = nodeTableStorageFactory.createBucketStorage(nodeRecord1);
+    NodeBucketStorage nodeBucketStorage1 =
+        nodeTableStorageFactory.createBucketStorage(localNodeRecordStoreAt1);
     NodeTableStorage nodeTableStorage2 = nodeTableStorageFactory.createTable(List.of(nodeRecord1));
-    NodeBucketStorage nodeBucketStorage2 = nodeTableStorageFactory.createBucketStorage(nodeRecord2);
+    NodeBucketStorage nodeBucketStorage2 =
+        nodeTableStorageFactory.createBucketStorage(
+            new LocalNodeRecordStore(
+                nodeRecord2, Bytes.EMPTY, NodeRecordListener.NOOP, NewAddressHandler.NOOP));
 
     // Node1 create AuthHeaderPacket
     LinkedBlockingQueue<RawPacket> outgoing1Packets = new LinkedBlockingQueue<>();
@@ -96,12 +106,6 @@ public class HandshakeHandlersTest {
           System.out.println("Outgoing packet from 1 to 2: " + parcel.getPacket());
           outgoing1Packets.add(parcel.getPacket());
         };
-    final LocalNodeRecordStore localNodeRecordStoreAt1 =
-        new LocalNodeRecordStore(
-            nodeRecord1,
-            nodePair1.getPrivateKey(),
-            NodeRecordListener.NOOP,
-            NewAddressHandler.NOOP);
     final ExpirationSchedulerFactory expirationSchedulerFactory =
         new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
     final ExpirationScheduler<Bytes> reqeustExpirationScheduler =

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandlerTest.java
@@ -29,7 +29,10 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.schema.NodeStatus;
+import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
+import org.ethereum.beacon.discovery.storage.NewAddressHandler;
 import org.ethereum.beacon.discovery.storage.NodeBucketStorage;
+import org.ethereum.beacon.discovery.storage.NodeRecordListener;
 import org.ethereum.beacon.discovery.storage.NodeTableStorageFactoryImpl;
 import org.ethereum.beacon.discovery.util.Functions;
 import org.junit.jupiter.api.Test;
@@ -42,7 +45,13 @@ public class FindNodeHandlerTest {
   private NodeInfo homeNodePair = TestUtil.generateUnverifiedNode(30303);
   private NodeRecord homeNodeRecord = homeNodePair.getNodeRecord();
   private NodeBucketStorage nodeBucketStorage =
-      new NodeTableStorageFactoryImpl().createBucketStorage(homeNodeRecord);
+      new NodeTableStorageFactoryImpl()
+          .createBucketStorage(
+              new LocalNodeRecordStore(
+                  homeNodeRecord,
+                  Bytes.fromHexString("0x1234"),
+                  NodeRecordListener.NOOP,
+                  NewAddressHandler.NOOP));
   private NodeSession session = mock(NodeSession.class);
   private Map<Integer, List<NodeRecord>> tableRecords = new HashMap<>();
 

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandlerTest.java
@@ -49,8 +49,10 @@ public class FindNodeHandlerTest {
   private FindNodeHandler nodeHandler = new FindNodeHandler();
 
   {
-    when(session.getBucket(anyInt()))
-        .thenAnswer(invocation -> nodeBucketStorage.get(invocation.getArgument(0, Integer.class)));
+    when(session.getNodeRecordsInBucket(anyInt()))
+        .thenAnswer(
+            invocation ->
+                nodeBucketStorage.getNodeRecords(invocation.getArgument(0, Integer.class)));
     for (int i = 0; i < 256; i++) {
       for (int j = 0; j < i % 3; j++) {
         NodeRecord record = generateNodeAtDistance(i);

--- a/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketStorageImplTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketStorageImplTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
+import org.junit.jupiter.api.Test;
+
+class NodeBucketStorageImplTest {
+  private final NodeInfo localNode = TestUtil.generateNode(9244);
+  private final LocalNodeRecordStore localNodeRecordStore =
+      new LocalNodeRecordStore(
+          localNode.getNodeRecord(), Bytes.EMPTY, NodeRecordListener.NOOP, NewAddressHandler.NOOP);
+
+  private final NodeBucketStorage storage = new NodeBucketStorageImpl(localNodeRecordStore);
+
+  @Test
+  void shouldReturnLatestLocalNodeWhenDistanceIsZero() {
+    assertThat(storage.getNodeRecords(0)).containsExactly(localNode.getNodeRecord());
+
+    // Should return the new record after updates
+    localNodeRecordStore.onCustomFieldValueChanged("eth2", Bytes.fromHexString("0x1324"));
+    // Sanity check the ENR actually changed
+    assertThat(localNodeRecordStore.getLocalNodeRecord()).isNotEqualTo(localNode.getNodeRecord());
+
+    assertThat(storage.getNodeRecords(0))
+        .containsExactly(localNodeRecordStore.getLocalNodeRecord());
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.TestUtil;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
@@ -72,7 +73,9 @@ public class NodeBucketTest {
     NodeRecordInfo initial = generateUniqueRecord(0);
     NodeTableStorageFactoryImpl nodeTableStorageFactory = new NodeTableStorageFactoryImpl();
     NodeBucketStorage nodeBucketStorage =
-        nodeTableStorageFactory.createBucketStorage(initial.getNode());
+        nodeTableStorageFactory.createBucketStorage(
+            new LocalNodeRecordStore(
+                initial.getNode(), Bytes.EMPTY, NodeRecordListener.NOOP, NewAddressHandler.NOOP));
 
     int j = 1;
     for (int i = 0; i < 20; ) {

--- a/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/NodeBucketTest.java
@@ -3,6 +3,7 @@
  */
 package org.ethereum.beacon.discovery.storage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,9 +93,9 @@ public class NodeBucketTest {
       }
       ++j;
     }
-    assertEquals(16, nodeBucketStorage.get(255).get().size());
-    assertEquals(3, nodeBucketStorage.get(254).get().size());
-    assertFalse(nodeBucketStorage.get(253).isPresent());
-    assertFalse(nodeBucketStorage.get(256).isPresent());
+    assertThat(nodeBucketStorage.getNodeRecords(255)).hasSize(16);
+    assertThat(nodeBucketStorage.getNodeRecords(254)).hasSize(3);
+    assertThat(nodeBucketStorage.getNodeRecords(253)).isEmpty();
+    assertThat(nodeBucketStorage.getNodeRecords(256)).isEmpty();
   }
 }


### PR DESCRIPTION
## PR Description
When requesting distance 0 from the bucket storage, always return the latest local node info rather than a previously stored version.