### PR TITLE
Update node table when newer ENRs received from FINDNODES

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -60,7 +60,7 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
     final NodeTable nodeTable = session.getNodeTable();
     final Bytes nodeId = nodeRecordV5.getNodeId();
     final Optional<NodeRecordInfo> existingRecord = nodeTable.getNode(nodeId);
-    if (isUpdated(nodeRecordV5, existingRecord)) {
+    if (isUpdateRequired(nodeRecordV5, existingRecord)) {
       // Update node table with new node record
       nodeTable.save(nodeRecordInfo);
 
@@ -71,7 +71,7 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
     }
   }
 
-  private boolean isUpdated(
+  private boolean isUpdateRequired(
       final NodeRecord newRecord, final Optional<NodeRecordInfo> existingRecord) {
     return existingRecord.isEmpty()
         || existingRecord.get().getNode().getSeq().compareTo(newRecord.getSeq()) < 0;

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery.message.handler;
 
 import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,14 +30,13 @@ import org.ethereum.beacon.discovery.storage.NodeTable;
 import org.ethereum.beacon.discovery.util.Functions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class NodesHandlerTest {
 
   private static final Bytes PEER_ID = Bytes.fromHexString("0x1234567890ABCDEF");
   private static final Bytes REQUEST_ID = Bytes.fromHexString("0x1234");
   private final NodeSession session = mock(NodeSession.class);
-  private final NodeTable nodeTable = Mockito.mock(NodeTable.class);
+  private final NodeTable nodeTable = mock(NodeTable.class);
   private final NodesHandler handler = new NodesHandler();
 
   @BeforeEach
@@ -63,6 +63,65 @@ class NodesHandlerTest {
     final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeInfo.getNodeRecord());
     verify(nodeTable).save(nodeRecordInfo);
     verify(session, never()).putRecordInBucket(nodeRecordInfo);
+    verify(session).clearRequestInfo(REQUEST_ID, null);
+  }
+
+  @Test
+  public void shouldUpdateNodeRecordsWhenSeqNumHigher() {
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
+    final NodeRecord originalRecord = nodeInfo.getNodeRecord();
+    when(nodeTable.getNode(originalRecord.getNodeId()))
+        .thenReturn(Optional.of(NodeRecordInfo.createDefault(originalRecord)));
+    final int distance = Functions.logDistance(PEER_ID, originalRecord.getNodeId());
+    Request<Void> request =
+        new Request<>(
+            new CompletableFuture<>(),
+            id -> new FindNodeMessage(id, singletonList(distance)),
+            new FindNodeResponseHandler());
+    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
+    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+
+    final NodeRecord updatedRecord =
+        originalRecord.withUpdatedCustomField(
+            "test", Bytes.fromHexString("0x8888"), nodeInfo.getPrivateKey());
+    final List<NodeRecord> records = singletonList(updatedRecord);
+    final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
+    handler.handle(message, session);
+
+    final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(updatedRecord);
+    verify(nodeTable).save(nodeRecordInfo);
+    verify(session, never()).updateNodeRecord(any());
+    verify(session, never()).putRecordInBucket(any());
+    verify(session).clearRequestInfo(REQUEST_ID, null);
+  }
+
+  @Test
+  public void shouldUpdateNodeRecordInSessionWhenSelfEnrReturnedWithHigherSeqNum() {
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
+    final NodeRecord originalRecord = nodeInfo.getNodeRecord();
+    when(nodeTable.getNode(originalRecord.getNodeId()))
+        .thenReturn(Optional.of(NodeRecordInfo.createDefault(originalRecord)));
+    Request<Void> request =
+        new Request<>(
+            new CompletableFuture<>(),
+            id -> new FindNodeMessage(id, singletonList(0)),
+            new FindNodeResponseHandler());
+    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
+    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    // Requesting from the node itself
+    when(session.getNodeId()).thenReturn(originalRecord.getNodeId());
+
+    final NodeRecord updatedRecord =
+        originalRecord.withUpdatedCustomField(
+            "test", Bytes.fromHexString("0x8888"), nodeInfo.getPrivateKey());
+    final List<NodeRecord> records = singletonList(updatedRecord);
+    final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
+    handler.handle(message, session);
+
+    final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(updatedRecord);
+    verify(nodeTable).save(nodeRecordInfo);
+    verify(session).updateNodeRecord(updatedRecord);
+    verify(session, never()).putRecordInBucket(any());
     verify(session).clearRequestInfo(REQUEST_ID, null);
   }
 


### PR DESCRIPTION
## PR Description
When a `NODES` message is received that contains a newer ENR for a previously discovered node, update it's record in the node table.

Note that it is not updated in the bucket storage because we haven't validated the liveness of the new ENR yet (that's done through separate liveness checks).