### PR TITLE
Add new implementation of k-bucket storage

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/BucketEntry.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/BucketEntry.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.KBuckets.LivenessChecker;
+
+class BucketEntry {
+
+  private static final int NEVER = -1;
+  static final long MIN_MILLIS_BETWEEN_PINGS = TimeUnit.SECONDS.toMillis(30);
+
+  /**
+   * Per discovery spec:
+   *
+   * <p>Since low-latency communication is expected, implementations should place short timeouts on
+   * request/response interactions. Good timeout values are 500ms for a single request/response and
+   * 1s for the handshake.
+   */
+  static final long PING_TIMEOUT_MILLIS = 500;
+
+  private final LivenessChecker livenessChecker;
+  private final NodeRecord node;
+  private final long lastLivenessConfirmationTime;
+  private long lastPingTime = NEVER;
+
+  BucketEntry(final LivenessChecker livenessChecker, final NodeRecord node) {
+    this(livenessChecker, node, NEVER);
+  }
+
+  BucketEntry(
+      final LivenessChecker livenessChecker,
+      final NodeRecord node,
+      final long lastLivenessConfirmationTime) {
+    this.livenessChecker = livenessChecker;
+    this.node = node;
+    this.lastLivenessConfirmationTime = lastLivenessConfirmationTime;
+  }
+
+  public Bytes getNodeId() {
+    return node.getNodeId();
+  }
+
+  public NodeRecord getNode() {
+    return node;
+  }
+
+  public void checkLiveness(final long currentTime) {
+    if (currentTime - lastPingTime >= MIN_MILLIS_BETWEEN_PINGS
+        && currentTime - lastLivenessConfirmationTime >= MIN_MILLIS_BETWEEN_PINGS) {
+      livenessChecker.checkLiveness(node);
+      lastPingTime = currentTime;
+    }
+  }
+
+  public boolean hasFailedLivenessCheck(final long currentTime) {
+    return lastLivenessConfirmationTime < lastPingTime // Haven't responded to last ping
+        && currentTime - lastPingTime >= PING_TIMEOUT_MILLIS;
+  }
+
+  /**
+   * A bucket entry is considered live if it has ever been confirmed as live. This avoids
+   * considering the node dead just because we haven't pinged it recently or because it is yet to
+   * respond to a ping.
+   *
+   * <p>Entries that fail to respond to a ping will eventually be removed from the k-buckets
+   * entirely and disposed.
+   *
+   * @return true if the node has ever been confirmed as live.
+   */
+  public boolean isLive() {
+    return lastLivenessConfirmationTime != NEVER;
+  }
+
+  public BucketEntry withLastConfirmedTime(final long currentTime) {
+    return new BucketEntry(livenessChecker, node, currentTime);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BucketEntry that = (BucketEntry) o;
+    return node.getNodeId().equals(that.node.getNodeId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(node.getNodeId());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("node", node)
+        .add("lastLivenessConfirmationTime", lastLivenessConfirmationTime)
+        .add("lastPingTime", lastPingTime)
+        .toString();
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.KBuckets.LivenessChecker;
+
+public class KBucket {
+
+  static final int K = 16;
+
+  private final LivenessChecker livenessChecker;
+  private final Clock clock;
+
+  private final List<BucketEntry> nodes = new ArrayList<>();
+
+  private Optional<BucketEntry> pendingNode = Optional.empty();
+
+  public KBucket(final LivenessChecker livenessChecker, final Clock clock) {
+    this.livenessChecker = livenessChecker;
+    this.clock = clock;
+  }
+
+  public List<NodeRecord> getAllNodes() {
+    return nodes.stream().map(BucketEntry::getNode).collect(Collectors.toList());
+  }
+
+  public List<NodeRecord> getLiveNodes() {
+    return nodes.stream()
+        .filter(node -> node.isLive())
+        .map(BucketEntry::getNode)
+        .collect(Collectors.toList());
+  }
+
+  public Optional<NodeRecord> getPendingNode() {
+    return pendingNode.map(BucketEntry::getNode);
+  }
+
+  public void offer(final NodeRecord node) {
+    performMaintenance();
+    getEntry(node)
+        .ifPresentOrElse(
+            existing -> updateExistingRecord(existing, node), () -> offerNewNode(node));
+  }
+
+  private void updateExistingRecord(final BucketEntry existing, final NodeRecord newRecord) {
+    if (existing.getNode().getSeq().compareTo(newRecord.getSeq()) >= 0) {
+      // New record isn't actually newer, do nothing.
+      return;
+    }
+    nodes.remove(existing);
+    final BucketEntry newEntry = new BucketEntry(livenessChecker, newRecord);
+    nodes.add(newEntry);
+    newEntry.checkLiveness(clock.millis());
+  }
+
+  private void offerNewNode(final NodeRecord node) {
+    if (isFull()) {
+      getLastNode().checkLiveness(clock.millis());
+      if (pendingNode.isEmpty()) {
+        livenessChecker.checkLiveness(node);
+      }
+    } else {
+      final BucketEntry newEntry = new BucketEntry(livenessChecker, node);
+      nodes.add(newEntry);
+      newEntry.checkLiveness(clock.millis());
+    }
+  }
+
+  public void onNodeContacted(final NodeRecord node) {
+    getEntry(node)
+        .ifPresentOrElse(
+            existingEntry -> {
+              // Move to the start of the bucket
+              nodes.remove(existingEntry);
+              nodes.add(0, existingEntry.withLastConfirmedTime(clock.millis()));
+              performMaintenance();
+            },
+            () -> {
+              if (pendingNode.isPresent()
+                  && pendingNode.get().getNodeId().equals(node.getNodeId())) {
+                // Update pending node
+                pendingNode = Optional.of(pendingNode.get().withLastConfirmedTime(clock.millis()));
+              }
+              performMaintenance();
+              if (isFull()) {
+                if (pendingNode.isEmpty()) {
+                  pendingNode = Optional.of(new BucketEntry(livenessChecker, node, clock.millis()));
+                }
+              } else {
+                nodes.add(0, new BucketEntry(livenessChecker, node, clock.millis()));
+              }
+            });
+  }
+
+  /**
+   * Performs any pending maintenance on the bucket.
+   *
+   * <p>If the pending node has not been pinged recently, schedule a ping for it.
+   *
+   * <p>If the pending node has not responded to the last ping within a reasonable time, remove it.
+   *
+   * <p>If the last node in the bucket has not been pinged recently, schedule a ping for it.
+   *
+   * <p>If the last node in the bucket has not responded to the last liveness check within a
+   * reasonable time:
+   *
+   * <p>a. remove it from the bucket.
+   *
+   * <p>b. if there is a pending node, insert it into the bucket (at appropriate position based on
+   * when it was last confirmed as live)
+   */
+  public void performMaintenance() {
+    if (nodes.isEmpty()) {
+      return;
+    }
+    final long currentTime = clock.millis();
+
+    performPendingNodeMaintenance(currentTime);
+
+    final BucketEntry lastNode = getLastNode();
+    if (lastNode.hasFailedLivenessCheck(currentTime)) {
+      nodes.remove(lastNode);
+      pendingNode.ifPresent(
+          pendingEntry -> {
+            nodes.add(0, pendingEntry);
+            pendingNode = Optional.empty();
+          });
+    } else {
+      lastNode.checkLiveness(currentTime);
+    }
+  }
+
+  private void performPendingNodeMaintenance(final long currentTime) {
+    pendingNode.ifPresent(
+        pendingEntry -> {
+          if (pendingEntry.hasFailedLivenessCheck(currentTime)) {
+            pendingNode = Optional.empty();
+          } else {
+            pendingEntry.checkLiveness(currentTime);
+          }
+        });
+  }
+
+  private BucketEntry getLastNode() {
+    return nodes.get(nodes.size() - 1);
+  }
+
+  private boolean isFull() {
+    return nodes.size() >= K;
+  }
+
+  private Optional<BucketEntry> getEntry(final NodeRecord nodeRecord) {
+    return nodes.stream().filter(node -> node.getNodeId().equals(nodeRecord.getNodeId())).findAny();
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.util.Functions;
+
+public class KBuckets {
+  public static final int MAXIMUM_BUCKET = 256;
+
+  private final LocalNodeRecordStore localNodeRecordStore;
+  private final Bytes homeNodeId;
+  private final LivenessChecker livenessChecker;
+  private final Map<Integer, KBucket> buckets = new HashMap<>();
+  private final Clock clock;
+
+  public KBuckets(
+      final Clock clock,
+      final LocalNodeRecordStore localNodeRecordStore,
+      final LivenessChecker livenessChecker) {
+    this.clock = clock;
+    this.localNodeRecordStore = localNodeRecordStore;
+    this.homeNodeId = localNodeRecordStore.getLocalNodeRecord().getNodeId();
+    this.livenessChecker = livenessChecker;
+  }
+
+  public synchronized Stream<NodeRecord> getLiveNodeRecords(int distance) {
+    if (distance == 0) {
+      return Stream.of(localNodeRecordStore.getLocalNodeRecord());
+    }
+    return getBucket(distance).stream().flatMap(bucket -> bucket.getLiveNodes().stream());
+  }
+
+  public synchronized Stream<NodeRecord> getAllNodeRecords(int distance) {
+    if (distance == 0) {
+      return Stream.of(localNodeRecordStore.getLocalNodeRecord());
+    }
+    return getBucket(distance).stream().flatMap(bucket -> bucket.getAllNodes().stream());
+  }
+
+  private Optional<KBucket> getBucket(final int distance) {
+    return Optional.ofNullable(buckets.get(distance));
+  }
+
+  public synchronized void offer(NodeRecord node) {
+    final int distance = Functions.logDistance(homeNodeId, node.getNodeId());
+    if (distance > MAXIMUM_BUCKET) {
+      // Distance too great, ignore.
+      return;
+    }
+    final KBucket bucket = getOrCreateBucket(distance);
+    bucket.offer(node);
+  }
+
+  /**
+   * Called when we have confirmed the liveness of a node by sending it a request and receiving a
+   * valid response back. Must only be called for requests we initiate, not incoming requests from
+   * the peer.
+   *
+   * @param node the node for which liveness was confirmed.
+   */
+  public synchronized void onNodeContacted(NodeRecord node) {
+    final int distance = Functions.logDistance(homeNodeId, node.getNodeId());
+    getOrCreateBucket(distance).onNodeContacted(node);
+  }
+
+  private KBucket getOrCreateBucket(final int distance) {
+    return buckets.computeIfAbsent(distance, __ -> new KBucket(livenessChecker, clock));
+  }
+
+  public interface LivenessChecker {
+
+    /**
+     * Adds the specified node to the queue of nodes to perform a liveness check on.
+     *
+     * @param node the node to check liveness
+     */
+    void checkLiveness(NodeRecord node);
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NodeBucket.java
@@ -8,15 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import org.apache.tuweni.bytes.Bytes;
-import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeStatus;
-import org.ethereum.beacon.discovery.util.RlpUtil;
-import org.web3j.rlp.RlpEncoder;
-import org.web3j.rlp.RlpList;
-import org.web3j.rlp.RlpString;
 
 /**
  * Storage for nodes, K-Bucket. Holds only {@link #K} nodes, replacing nodes with the same nodeId
@@ -33,14 +26,6 @@ public class NodeBucket {
 
   private final TreeSet<NodeRecordInfo> bucket =
       new TreeSet<>((o1, o2) -> o2.getNode().hashCode() - o1.getNode().hashCode());
-
-  public static NodeBucket fromRlpBytes(Bytes bytes, NodeRecordFactory nodeRecordFactory) {
-    NodeBucket nodeBucket = new NodeBucket();
-    RlpUtil.decodeListOfStrings(bytes).stream()
-        .map(bytes1 -> NodeRecordInfo.fromRlpBytes(bytes1, nodeRecordFactory))
-        .forEach(nodeBucket::put);
-    return nodeBucket;
-  }
 
   public synchronized boolean put(NodeRecordInfo nodeRecord) {
     if (FILTER.test(nodeRecord)) {
@@ -75,18 +60,6 @@ public class NodeBucket {
 
   public synchronized boolean contains(NodeRecordInfo nodeRecordInfo) {
     return bucket.contains(nodeRecordInfo);
-  }
-
-  public synchronized Bytes toRlpBytes() {
-    byte[] res =
-        RlpEncoder.encode(
-            new RlpList(
-                bucket.stream()
-                    .map(NodeRecordInfo::toRlpBytes)
-                    .map(Bytes::toArray)
-                    .map(RlpString::create)
-                    .collect(Collectors.toList())));
-    return Bytes.wrap(res);
   }
 
   public int size() {

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -51,6 +51,9 @@ public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterprete
   public Optional<InetSocketAddress> getUdpAddress(final NodeRecord nodeRecord) {
     try {
       final Bytes ipBytes = (Bytes) nodeRecord.get(EnrField.IP_V4);
+      if (ipBytes == null) {
+        return Optional.empty();
+      }
       final InetAddress ipAddress = InetAddress.getByAddress(ipBytes.toArrayUnsafe());
       final int port = (int) nodeRecord.get(EnrField.UDP);
       return Optional.of(new InetSocketAddress(ipAddress, port));

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -4,7 +4,9 @@
 
 package org.ethereum.beacon.discovery;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
@@ -47,7 +49,14 @@ public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterprete
 
   @Override
   public Optional<InetSocketAddress> getUdpAddress(final NodeRecord nodeRecord) {
-    return Optional.ofNullable((InetSocketAddress) nodeRecord.get(UDP_ADDRESS));
+    try {
+      final Bytes ipBytes = (Bytes) nodeRecord.get(EnrField.IP_V4);
+      final InetAddress ipAddress = InetAddress.getByAddress(ipBytes.toArrayUnsafe());
+      final int port = (int) nodeRecord.get(EnrField.UDP);
+      return Optional.of(new InetSocketAddress(ipAddress, port));
+    } catch (UnknownHostException e) {
+      return Optional.empty();
+    }
   }
 
   @Override

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -26,7 +26,8 @@ public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterprete
             UInt64.ONE,
             new EnrField(EnrField.ID, IdentitySchema.V4),
             new EnrField(EnrField.PKEY_SECP256K1, nodeId),
-            new EnrField(UDP_ADDRESS, udpAddress));
+            new EnrField(EnrField.IP_V4, Bytes.wrap(udpAddress.getAddress().getAddress())),
+            new EnrField(EnrField.UDP, udpAddress.getPort()));
   }
 
   @Override

--- a/src/test/java/org/ethereum/beacon/discovery/StubClock.java
+++ b/src/test/java/org/ethereum/beacon/discovery/StubClock.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class StubClock extends Clock {
+
+  // Start from something realistic instead of 0.
+  private long currentTimeMillis = 1_000_000;
+
+  public void advanceTimeMillis(final long millis) {
+    currentTimeMillis += millis;
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return ZoneId.of("UTC");
+  }
+
+  @Override
+  public Clock withZone(final ZoneId zone) {
+    throw new UnsupportedOperationException("Timezone conversion not supported");
+  }
+
+  @Override
+  public Instant instant() {
+    return Instant.ofEpochMilli(currentTimeMillis);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/storage/BucketEntryTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/BucketEntryTest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ethereum.beacon.discovery.storage.BucketEntry.MIN_MILLIS_BETWEEN_PINGS;
+import static org.ethereum.beacon.discovery.storage.BucketEntry.PING_TIMEOUT_MILLIS;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.KBuckets.LivenessChecker;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BucketEntryTest {
+
+  private static final int START_TIME = 1_000_000;
+  private final NodeRecord nodeRecord = TestUtil.generateNode(9482).getNodeRecord();
+  private final LivenessChecker livenessChecker = Mockito.mock(LivenessChecker.class);
+  private BucketEntry entry = new BucketEntry(livenessChecker, nodeRecord);
+
+  @Test
+  void checkLiveness_shouldCheckLivenessWhenNeverPinged() {
+    entry.checkLiveness(START_TIME);
+    verify(livenessChecker).checkLiveness(nodeRecord);
+  }
+
+  @Test
+  void checkLiveness_shouldNotCheckLivenessWhenPingSentRecently() {
+    entry.checkLiveness(START_TIME);
+    verify(livenessChecker).checkLiveness(nodeRecord);
+
+    entry.checkLiveness(START_TIME + MIN_MILLIS_BETWEEN_PINGS - 1);
+    verifyNoMoreInteractions(livenessChecker);
+  }
+
+  @Test
+  void checkLiveness_shouldNotCheckLivenessWhenLivenessConfirmedRecently() {
+    createEntryWithLivenessConfirmationTime(START_TIME);
+
+    entry.checkLiveness(START_TIME + 1);
+    verifyNoMoreInteractions(livenessChecker);
+  }
+
+  @Test
+  void hasFailedLivenessCheck_shouldBeFalseWhenNoLivenessCheckPerformed() {
+    assertThat(entry.hasFailedLivenessCheck(10000000)).isFalse();
+  }
+
+  @Test
+  void hasFailedLivenessCheck_shouldBeTrueWhenLastPingNotRespondedToInTime() {
+    entry.checkLiveness(START_TIME);
+
+    assertThat(entry.hasFailedLivenessCheck(START_TIME + PING_TIMEOUT_MILLIS)).isTrue();
+  }
+
+  @Test
+  void hasFailedLivenessCheck_shouldBeFalseWhenLastPingWithinTimeout() {
+    entry.checkLiveness(START_TIME);
+
+    assertThat(entry.hasFailedLivenessCheck(START_TIME + PING_TIMEOUT_MILLIS - 1)).isFalse();
+  }
+
+  @Test
+  void isLive_shouldBeLiveIfConfirmed() {
+    createEntryWithLivenessConfirmationTime(START_TIME + 4000);
+    assertThat(entry.isLive()).isTrue();
+  }
+
+  @Test
+  void isLive_shouldBeLiveIfConfirmedPriorToLastPing() {
+    createEntryWithLivenessConfirmationTime(START_TIME + 4000);
+    entry.checkLiveness(START_TIME + MIN_MILLIS_BETWEEN_PINGS + 1);
+    assertThat(entry.isLive()).isTrue();
+  }
+
+  @Test
+  void isLive_shouldNotBeLiveWhenNotConfirmed() {
+    assertThat(entry.isLive()).isFalse();
+  }
+
+  private void createEntryWithLivenessConfirmationTime(final int lastLivenessConfirmationTime) {
+    entry = new BucketEntry(livenessChecker, nodeRecord, lastLivenessConfirmationTime);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
@@ -78,7 +78,7 @@ class KBucketTest {
     final NodeRecord lastRecordInBucket = fillBucketWithLiveNodes();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
 
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
@@ -156,7 +156,7 @@ class KBucketTest {
   void offer_shouldRemovePendingNodeIfTimedOutBeforeConsideringNewNode() {
     fillBucketWithLiveNodes();
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
 
     // Pending node times out
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
@@ -177,13 +177,13 @@ class KBucketTest {
   void offer_shouldReplaceLastNodeIfItAndPendingNodeAreTimedOut() {
     final NodeRecord lastNodeInBucket = fillBucketWithLiveNodes();
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
 
     // Pending node times out
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
     bucket.getAllNodes().stream()
         .filter(node -> !node.equals(lastNodeInBucket))
-        .forEach(bucket::onNodeContacted);
+        .forEach(bucket::onLivenessConfirmed);
     bucket.performMaintenance();
     verify(livenessChecker).checkLiveness(pendingNode);
     verify(livenessChecker, times(2)).checkLiveness(lastNodeInBucket);
@@ -203,7 +203,7 @@ class KBucketTest {
   void onNodeContacted_shouldMoveExistingNodeToFrontOfBucket() {
     final NodeRecord lastNode = fillBucket();
 
-    bucket.onNodeContacted(lastNode);
+    bucket.onLivenessConfirmed(lastNode);
 
     assertThat(bucket.getAllNodes()).startsWith(lastNode);
   }
@@ -213,10 +213,10 @@ class KBucketTest {
     final NodeRecord node1 = createNewNodeRecord();
     final NodeRecord node2 = createNewNodeRecord();
 
-    bucket.onNodeContacted(node1);
+    bucket.onLivenessConfirmed(node1);
     assertThat(bucket.getAllNodes()).containsExactly(node1);
 
-    bucket.onNodeContacted(node2);
+    bucket.onLivenessConfirmed(node2);
     assertThat(bucket.getAllNodes()).containsExactly(node2, node1);
   }
 
@@ -225,11 +225,11 @@ class KBucketTest {
     fillBucket();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
 
     final NodeRecord node2 = createNewNodeRecord();
-    bucket.onNodeContacted(node2);
+    bucket.onLivenessConfirmed(node2);
     assertThat(bucket.getAllNodes()).doesNotContain(node2);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
   }
@@ -242,7 +242,7 @@ class KBucketTest {
     clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
 
     // Timeout pending node
@@ -253,7 +253,7 @@ class KBucketTest {
 
     // New node should replace the timed out pending node
     final NodeRecord newNode = createNewNodeRecord();
-    bucket.onNodeContacted(newNode);
+    bucket.onLivenessConfirmed(newNode);
 
     assertThat(bucket.getPendingNode()).contains(newNode);
     assertThat(bucket.getAllNodes()).doesNotContain(pendingNode);
@@ -266,7 +266,7 @@ class KBucketTest {
     clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
 
     final NodeRecord newNode = createNewNodeRecord();
-    bucket.onNodeContacted(newNode);
+    bucket.onLivenessConfirmed(newNode);
 
     assertThat(bucket.getAllNodes()).contains(newNode).doesNotContain(lastNode);
     assertThat(bucket.getPendingNode()).isEmpty();
@@ -279,7 +279,7 @@ class KBucketTest {
     clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
 
     // Timeout last node
@@ -290,14 +290,14 @@ class KBucketTest {
     final NodeRecord lastNode = getLastNodeInBucket();
     bucket.getAllNodes().stream()
         .filter(node -> !node.equals(lastNode))
-        .forEach(bucket::onNodeContacted);
-    bucket.onNodeContacted(pendingNode);
+        .forEach(bucket::onLivenessConfirmed);
+    bucket.onLivenessConfirmed(pendingNode);
 
     clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
 
     // Pending node should replace the timed out last node and new node becomes pending
     final NodeRecord newNode = createNewNodeRecord();
-    bucket.onNodeContacted(newNode);
+    bucket.onLivenessConfirmed(newNode);
 
     assertThat(bucket.getAllNodes()).contains(pendingNode).doesNotContain(lastNode);
     assertThat(bucket.getPendingNode()).contains(newNode);
@@ -309,11 +309,11 @@ class KBucketTest {
     confirmNodesInBucketAsLive();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     verify(livenessChecker, never()).checkLiveness(pendingNode);
 
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     // No need to ping pending node because we know its live
     verify(livenessChecker, never()).checkLiveness(pendingNode);
 
@@ -346,7 +346,7 @@ class KBucketTest {
     final NodeRecord lastRecordInBucket = fillBucket();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
     assertThat(bucket.getPendingNode()).contains(pendingNode);
 
     // First offered node schedules a ping for the last node and the new node
@@ -369,7 +369,7 @@ class KBucketTest {
     fillBucket();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
 
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
 
@@ -382,7 +382,7 @@ class KBucketTest {
     fillBucket();
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
 
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS - 1);
 
@@ -396,7 +396,7 @@ class KBucketTest {
     confirmNodesInBucketAsLive(); // Existing nodes stay live
 
     final NodeRecord pendingNode = createNewNodeRecord();
-    bucket.onNodeContacted(pendingNode);
+    bucket.onLivenessConfirmed(pendingNode);
 
     clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
     confirmNodesInBucketAsLive(); // Existing nodes stay live
@@ -419,16 +419,16 @@ class KBucketTest {
     final NodeRecord node4 = createNewNodeRecord();
 
     bucket.offer(node1);
-    bucket.onNodeContacted(node2);
+    bucket.onLivenessConfirmed(node2);
     bucket.offer(node3);
-    bucket.onNodeContacted(node4);
+    bucket.onLivenessConfirmed(node4);
 
     assertThat(bucket.getAllNodes()).containsExactly(node4, node2, node1, node3);
     assertThat(bucket.getLiveNodes()).containsExactly(node4, node2);
   }
 
   private void confirmNodesInBucketAsLive() {
-    bucket.getAllNodes().forEach(bucket::onNodeContacted);
+    bucket.getAllNodes().forEach(bucket::onLivenessConfirmed);
   }
 
   private NodeRecord fillBucket() {

--- a/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
@@ -1,0 +1,457 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ethereum.beacon.discovery.storage.BucketEntry.MIN_MILLIS_BETWEEN_PINGS;
+import static org.ethereum.beacon.discovery.storage.BucketEntry.PING_TIMEOUT_MILLIS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.StubClock;
+import org.ethereum.beacon.discovery.TestUtil;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.KBuckets.LivenessChecker;
+import org.junit.jupiter.api.Test;
+
+class KBucketTest {
+
+  private final LivenessChecker livenessChecker = mock(LivenessChecker.class);
+
+  private final StubClock clock = new StubClock();
+  private final KBucket bucket = new KBucket(livenessChecker, clock);
+
+  private int lastNodeRecordPort = 0;
+
+  @Test
+  void offer_shouldAddNodeAndCheckLivenessWhenTheBucketIsEmpty() {
+    final NodeRecord node = createNewNodeRecord();
+    bucket.offer(node);
+
+    assertThat(bucket.getAllNodes()).containsExactly(node);
+    assertThat(bucket.getLiveNodes()).isEmpty();
+
+    verify(livenessChecker).checkLiveness(node);
+  }
+
+  @Test
+  void offer_shouldAddNodeAndCheckLivenessWhenBucketIsNotYetFull() {
+    final NodeRecord node1 = createNewNodeRecord();
+    final NodeRecord node2 = createNewNodeRecord();
+    final NodeRecord node3 = createNewNodeRecord();
+    bucket.offer(node1);
+    bucket.offer(node2);
+    bucket.offer(node3);
+
+    assertThat(bucket.getAllNodes()).containsExactly(node1, node2, node3);
+    assertThat(bucket.getLiveNodes()).isEmpty();
+
+    verify(livenessChecker).checkLiveness(node1);
+    verify(livenessChecker).checkLiveness(node2);
+    verify(livenessChecker).checkLiveness(node3);
+  }
+
+  @Test
+  void offer_shouldPingLastNodeInBucketAndNewNodeWhenBucketFullWithNoPending() {
+    final NodeRecord lastRecordInBucket = fillBucketWithLiveNodes();
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.offer(newNode);
+
+    // Should trigger a new liveness check for the last item in the bucket
+    verify(livenessChecker, times(2)).checkLiveness(lastRecordInBucket);
+
+    // Should check the new node to see if it can be used as the pending node
+    verify(livenessChecker).checkLiveness(newNode);
+    // But doesn't add it to the bucket
+    assertThat(bucket.getAllNodes()).doesNotContain(newNode);
+  }
+
+  @Test
+  void offer_shouldPingLastNodeInBucketButNotNewNodeWhenBucketFullWithPendingEntry() {
+    final NodeRecord lastRecordInBucket = fillBucketWithLiveNodes();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.offer(newNode);
+
+    // We already have a pending node so ignore the new node
+    verify(livenessChecker, never()).checkLiveness(newNode);
+
+    // Should still trigger a new liveness check for the last item in the bucket
+    verify(livenessChecker, times(2)).checkLiveness(lastRecordInBucket);
+
+    // But doesn't add it to the bucket
+    assertThat(bucket.getAllNodes()).doesNotContain(newNode);
+  }
+
+  @Test
+  void offer_shouldUpdateExistingEntryInBucket() {
+    final NodeRecord nodeSeq1 = createNewNodeRecord();
+    final NodeRecord nodeSeq2 =
+        nodeSeq1.withUpdatedCustomField("hello", Bytes.fromHexString("0x1234"), Bytes.EMPTY);
+
+    bucket.offer(nodeSeq1);
+    bucket.offer(nodeSeq2);
+    verify(livenessChecker).checkLiveness(nodeSeq1);
+    verify(livenessChecker).checkLiveness(nodeSeq2);
+
+    assertThat(bucket.getAllNodes()).containsExactly(nodeSeq2);
+  }
+
+  @Test
+  void offer_shouldNotUpdateExistingEntryWhenNewRecordIsOlder() {
+    final NodeRecord nodeSeq1 = createNewNodeRecord();
+    final NodeRecord nodeSeq2 =
+        nodeSeq1.withUpdatedCustomField("record", Bytes.fromHexString("0x1234"), Bytes.EMPTY);
+
+    bucket.offer(nodeSeq2);
+    bucket.offer(nodeSeq1);
+    verify(livenessChecker).checkLiveness(nodeSeq2);
+    verify(livenessChecker, never()).checkLiveness(nodeSeq1);
+
+    assertThat(bucket.getAllNodes()).containsExactly(nodeSeq2);
+  }
+
+  @Test
+  void offer_shouldNotUpdateExistingEntryWhenNewRecordIsSameAge() {
+    final NodeRecord nodeSeq1 = createNewNodeRecord();
+
+    bucket.offer(nodeSeq1);
+    bucket.offer(nodeSeq1);
+
+    // Only checks liveness once
+    verify(livenessChecker).checkLiveness(nodeSeq1);
+    assertThat(bucket.getAllNodes()).containsExactly(nodeSeq1);
+  }
+
+  @Test
+  void offer_shouldMoveUpdatedNodeToEndOfBucket() {
+    final NodeRecord otherNode = createNewNodeRecord();
+    final NodeRecord nodeSeq1 = createNewNodeRecord();
+    final NodeRecord nodeSeq2 =
+        nodeSeq1.withUpdatedCustomField("hello", Bytes.fromHexString("0x1234"), Bytes.EMPTY);
+
+    bucket.offer(nodeSeq1);
+    bucket.offer(otherNode);
+
+    assertThat(bucket.getAllNodes()).containsExactly(nodeSeq1, otherNode);
+
+    bucket.offer(nodeSeq2);
+    assertThat(bucket.getAllNodes()).containsExactly(otherNode, nodeSeq2);
+  }
+
+  @Test
+  void offer_shouldRemovePendingNodeIfTimedOutBeforeConsideringNewNode() {
+    fillBucketWithLiveNodes();
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+
+    // Pending node times out
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    confirmNodesInBucketAsLive();
+    bucket.performMaintenance();
+    verify(livenessChecker).checkLiveness(pendingNode);
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    // Timed out pending node is removed on the next call to offer
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.offer(newNode);
+    assertThat(bucket.getPendingNode()).isEmpty();
+    verify(livenessChecker).checkLiveness(newNode);
+  }
+
+  @Test
+  void offer_shouldReplaceLastNodeIfItAndPendingNodeAreTimedOut() {
+    final NodeRecord lastNodeInBucket = fillBucketWithLiveNodes();
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+
+    // Pending node times out
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    bucket.getAllNodes().stream()
+        .filter(node -> !node.equals(lastNodeInBucket))
+        .forEach(bucket::onNodeContacted);
+    bucket.performMaintenance();
+    verify(livenessChecker).checkLiveness(pendingNode);
+    verify(livenessChecker, times(2)).checkLiveness(lastNodeInBucket);
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+    assertThat(bucket.getAllNodes()).contains(lastNodeInBucket);
+
+    // Timed out pending node is removed on the next call to offer
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.offer(newNode);
+    assertThat(bucket.getPendingNode()).isEmpty();
+    assertThat(bucket.getAllNodes()).contains(newNode).doesNotContain(lastNodeInBucket);
+    verify(livenessChecker).checkLiveness(newNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldMoveExistingNodeToFrontOfBucket() {
+    final NodeRecord lastNode = fillBucket();
+
+    bucket.onNodeContacted(lastNode);
+
+    assertThat(bucket.getAllNodes()).startsWith(lastNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldAddNodeToFrontOfBucketWhenNotFull() {
+    final NodeRecord node1 = createNewNodeRecord();
+    final NodeRecord node2 = createNewNodeRecord();
+
+    bucket.onNodeContacted(node1);
+    assertThat(bucket.getAllNodes()).containsExactly(node1);
+
+    bucket.onNodeContacted(node2);
+    assertThat(bucket.getAllNodes()).containsExactly(node2, node1);
+  }
+
+  @Test
+  void onNodeContacted_shouldIgnoreNodeWhenBucketFullAndPendingEntryAlreadyExists() {
+    fillBucket();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    final NodeRecord node2 = createNewNodeRecord();
+    bucket.onNodeContacted(node2);
+    assertThat(bucket.getAllNodes()).doesNotContain(node2);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldReplacePendingEntryIfItHasTimedOut() {
+    fillBucket();
+    confirmNodesInBucketAsLive();
+
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    // Timeout pending node
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    bucket.performMaintenance();
+    confirmNodesInBucketAsLive();
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+
+    // New node should replace the timed out pending node
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.onNodeContacted(newNode);
+
+    assertThat(bucket.getPendingNode()).contains(newNode);
+    assertThat(bucket.getAllNodes()).doesNotContain(pendingNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldReplaceLastNodeIfItHasTimedOut() {
+    final NodeRecord lastNode = fillBucket();
+
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.onNodeContacted(newNode);
+
+    assertThat(bucket.getAllNodes()).contains(newNode).doesNotContain(lastNode);
+    assertThat(bucket.getPendingNode()).isEmpty();
+  }
+
+  @Test
+  void onNodeContacted_shouldReplaceTimedOutLastNodeWithPendingAndUseNewNodeAsPending() {
+    fillBucketWithLiveNodes();
+
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    // Timeout last node
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    bucket.performMaintenance();
+
+    // Everything except the last node responds to the ping
+    final NodeRecord lastNode = getLastNodeInBucket();
+    bucket.getAllNodes().stream()
+        .filter(node -> !node.equals(lastNode))
+        .forEach(bucket::onNodeContacted);
+    bucket.onNodeContacted(pendingNode);
+
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+
+    // Pending node should replace the timed out last node and new node becomes pending
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.onNodeContacted(newNode);
+
+    assertThat(bucket.getAllNodes()).contains(pendingNode).doesNotContain(lastNode);
+    assertThat(bucket.getPendingNode()).contains(newNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldUpdateLivenessConfirmationTimeForPendingNode() {
+    fillBucket();
+    confirmNodesInBucketAsLive();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    verify(livenessChecker, never()).checkLiveness(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    bucket.onNodeContacted(pendingNode);
+    // No need to ping pending node because we know its live
+    verify(livenessChecker, never()).checkLiveness(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS - 1);
+    bucket.performMaintenance();
+    // Still not need to ping because it the last contact updated the time
+    verify(livenessChecker, never()).checkLiveness(pendingNode);
+  }
+
+  @Test
+  void performMaintenance_shouldRemoveLastNodeInBucketWhenItHasFailedToRespondToPingForTooLong() {
+    final NodeRecord lastRecordInBucket = fillBucket();
+
+    // First offered node schedules a ping for the last node and the new node
+    final NodeRecord newNode = createNewNodeRecord();
+    bucket.offer(newNode);
+    verify(livenessChecker).checkLiveness(lastRecordInBucket);
+    verify(livenessChecker).checkLiveness(newNode);
+
+    clock.advanceTimeMillis(BucketEntry.PING_TIMEOUT_MILLIS);
+
+    // When bucket is randomly selected to perform maintenance, the last record is removed
+    bucket.performMaintenance();
+
+    assertThat(bucket.getAllNodes()).doesNotContain(lastRecordInBucket);
+  }
+
+  @Test
+  void performMaintenance_shouldInsertPendingNodeWhenLastNodeRemoved() {
+    final NodeRecord lastRecordInBucket = fillBucket();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    // First offered node schedules a ping for the last node and the new node
+    bucket.offer(pendingNode);
+    verify(livenessChecker).checkLiveness(lastRecordInBucket);
+
+    clock.advanceTimeMillis(BucketEntry.PING_TIMEOUT_MILLIS);
+
+    // When bucket is randomly selected to perform maintenance, the last record is removed
+    bucket.performMaintenance();
+
+    assertThat(bucket.getAllNodes()).doesNotContain(lastRecordInBucket);
+    // Newest inserted node goes first in the bucket
+    assertThat(bucket.getAllNodes()).startsWith(pendingNode);
+    assertThat(bucket.getPendingNode()).isEmpty();
+  }
+
+  @Test
+  void performMaintenance_shouldCheckLivenessOfPendingNodeIfRequired() {
+    fillBucket();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+
+    bucket.performMaintenance();
+    verify(livenessChecker).checkLiveness(pendingNode);
+  }
+
+  @Test
+  void performMaintenance_shouldNotCheckLivenessOfPendingNodeWhenRecentlyConfirmed() {
+    fillBucket();
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS - 1);
+
+    bucket.performMaintenance();
+    verify(livenessChecker, never()).checkLiveness(pendingNode);
+  }
+
+  @Test
+  void performMaintenance_shouldRemovePendingNodeIfPingTimedOut() {
+    fillBucket();
+    confirmNodesInBucketAsLive(); // Existing nodes stay live
+
+    final NodeRecord pendingNode = createNewNodeRecord();
+    bucket.onNodeContacted(pendingNode);
+
+    clock.advanceTimeMillis(MIN_MILLIS_BETWEEN_PINGS);
+    confirmNodesInBucketAsLive(); // Existing nodes stay live
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    bucket.performMaintenance();
+    verify(livenessChecker).checkLiveness(pendingNode);
+    assertThat(bucket.getPendingNode()).contains(pendingNode);
+
+    clock.advanceTimeMillis(PING_TIMEOUT_MILLIS);
+    bucket.performMaintenance();
+    assertThat(bucket.getPendingNode()).isEmpty();
+  }
+
+  @Test
+  void getLiveNodes_shouldOnlyReturnedConfirmedLiveNodes() {
+    final NodeRecord node1 = createNewNodeRecord();
+    final NodeRecord node2 = createNewNodeRecord();
+    final NodeRecord node3 = createNewNodeRecord();
+    final NodeRecord node4 = createNewNodeRecord();
+
+    bucket.offer(node1);
+    bucket.onNodeContacted(node2);
+    bucket.offer(node3);
+    bucket.onNodeContacted(node4);
+
+    assertThat(bucket.getAllNodes()).containsExactly(node4, node2, node1, node3);
+    assertThat(bucket.getLiveNodes()).containsExactly(node4, node2);
+  }
+
+  private void confirmNodesInBucketAsLive() {
+    bucket.getAllNodes().forEach(bucket::onNodeContacted);
+  }
+
+  private NodeRecord fillBucket() {
+    for (int i = 0; i < KBucket.K - 1; i++) {
+      bucket.offer(createNewNodeRecord());
+    }
+    final NodeRecord lastRecord = createNewNodeRecord();
+    bucket.offer(lastRecord);
+    return lastRecord;
+  }
+
+  private NodeRecord createNewNodeRecord() {
+    lastNodeRecordPort++;
+    return TestUtil.generateNode(lastNodeRecordPort).getNodeRecord();
+  }
+
+  private NodeRecord getLastNodeInBucket() {
+    return bucket.getAllNodes().get(bucket.getAllNodes().size() - 1);
+  }
+
+  private NodeRecord fillBucketWithLiveNodes() {
+    fillBucket();
+    confirmNodesInBucketAsLive();
+    return getLastNodeInBucket();
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/KBucketTest.java
@@ -422,9 +422,10 @@ class KBucketTest {
     bucket.onLivenessConfirmed(node2);
     bucket.offer(node3);
     bucket.onLivenessConfirmed(node4);
+    bucket.onLivenessConfirmed(node3);
 
-    assertThat(bucket.getAllNodes()).containsExactly(node4, node2, node1, node3);
-    assertThat(bucket.getLiveNodes()).containsExactly(node4, node2);
+    assertThat(bucket.getAllNodes()).containsExactly(node3, node4, node2, node1);
+    assertThat(bucket.getLiveNodes()).containsExactly(node3, node4, node2);
   }
 
   private void confirmNodesInBucketAsLive() {

--- a/src/test/java/org/ethereum/beacon/discovery/storage/KBucketsTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/KBucketsTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.util.BitSet;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
+import org.ethereum.beacon.discovery.StubClock;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.storage.KBuckets.LivenessChecker;
+import org.ethereum.beacon.discovery.util.Functions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class KBucketsTest {
+
+  private static final int ID_SIZE = 32;
+  private final LocalNodeRecordStore localNodeRecordStore = mock(LocalNodeRecordStore.class);
+  private final LivenessChecker livenessChecker = mock(LivenessChecker.class);
+  private final StubClock clock = new StubClock();
+  private final NodeRecord localNode =
+      SimpleIdentitySchemaInterpreter.createNodeRecord(
+          Bytes.wrap(new byte[ID_SIZE]), new InetSocketAddress("127.0.0.1", 1));
+
+  private KBuckets buckets;
+
+  @BeforeEach
+  void setUp() {
+    when(localNodeRecordStore.getLocalNodeRecord()).thenReturn(localNode);
+    buckets = new KBuckets(clock, localNodeRecordStore, livenessChecker);
+  }
+
+  @Test
+  void getNodeRecords_shouldReturnLocalRecordForDistanceZero() {
+    assertThat(buckets.getLiveNodeRecords(0)).containsExactly(localNode);
+  }
+
+  @Test
+  void onNodeContacted_shouldDelegateToCorrectBucket() {
+    final int distance = 8;
+    final NodeRecord node = createNodeAtDistance(distance);
+    buckets.onNodeContacted(node);
+
+    assertThat(buckets.getLiveNodeRecords(distance)).containsExactly(node);
+  }
+
+  @Test
+  void offer_shouldDelegateToCorrectBucket() {
+    final int distance = 8;
+    final NodeRecord node = createNodeAtDistance(distance);
+    buckets.offer(node);
+
+    assertThat(buckets.getAllNodeRecords(distance)).containsExactly(node);
+  }
+
+  @Test
+  void shouldGenerateIdsAtCorrectDistance() {
+    for (int distance = 1; distance <= 256; distance++) {
+      final NodeRecord node = createNodeAtDistance(distance);
+      assertThat(Functions.logDistance(localNode.getNodeId(), node.getNodeId()))
+          .isEqualTo(distance);
+    }
+  }
+
+  private NodeRecord createNodeAtDistance(final int distance) {
+    final BitSet bits = new BitSet(ID_SIZE * Byte.SIZE);
+    bits.set(distance - 1);
+    final byte[] targetNodeId = new byte[ID_SIZE];
+    final byte[] src = bits.toByteArray();
+    System.arraycopy(src, 0, targetNodeId, 0, src.length);
+    final Bytes nodeId = Bytes.wrap(targetNodeId).reverse();
+    return SimpleIdentitySchemaInterpreter.createNodeRecord(
+        nodeId, new InetSocketAddress("127.0.0.1", 2));
+  }
+}


### PR DESCRIPTION
## PR Description
Add a new implementation of k-bucket storage that also handles the scheduling of liveness checks for nodes in those buckets.

Currently this isn't actually plugged in anywhere and the `LivenessChecker` is just an interface with no implementation. However this shows the most critical logic around maintaining the node table entries.

## Fixed Issue(s)
Part of #103 
