### PR TITLE
Don't assume that nodes are in the node table when sending requests

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -44,7 +44,6 @@ import org.ethereum.beacon.discovery.scheduler.ExpirationSchedulerFactory;
 import org.ethereum.beacon.discovery.scheduler.Scheduler;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
-import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.ethereum.beacon.discovery.storage.NodeBucketStorage;
@@ -62,7 +61,6 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
   private final Pipeline incomingPipeline = new PipelineImpl();
   private final Pipeline outgoingPipeline = new PipelineImpl();
   private final LocalNodeRecordStore localNodeRecordStore;
-  private final NodeTable nodeTable;
   private volatile DiscoveryClient discoveryClient;
   private final NodeSessionManager nodeSessionManager;
 
@@ -76,7 +74,6 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
       Scheduler taskScheduler,
       ExpirationSchedulerFactory expirationSchedulerFactory,
       TalkHandler talkHandler) {
-    this.nodeTable = nodeTable;
     this.localNodeRecordStore = localNodeRecordStore;
     final NodeRecord homeNodeRecord = localNodeRecordStore.getLocalNodeRecord();
 
@@ -161,15 +158,8 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
     return request.getResultPromise();
   }
 
-  private void addNode(NodeRecord nodeRecord) {
-    if (nodeTable.getNode(nodeRecord.getNodeId()).isEmpty()) {
-      nodeTable.save(NodeRecordInfo.createDefault(nodeRecord));
-    }
-  }
-
   @Override
   public CompletableFuture<Void> findNodes(NodeRecord nodeRecord, List<Integer> distances) {
-    addNode(nodeRecord);
     Request<Void> request =
         new Request<>(
             new CompletableFuture<>(),
@@ -180,7 +170,6 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
 
   @Override
   public CompletableFuture<Void> ping(NodeRecord nodeRecord) {
-    addNode(nodeRecord);
     Request<Void> request =
         new Request<>(
             new CompletableFuture<>(),
@@ -191,7 +180,6 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
 
   @Override
   public CompletableFuture<Bytes> talk(NodeRecord nodeRecord, Bytes protocol, Bytes requestBytes) {
-    addNode(nodeRecord);
     Request<Bytes> request =
         new Request<>(
             new CompletableFuture<>(),

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
@@ -29,6 +29,6 @@ public class NodeSessionRequestHandler implements EnvelopeHandler {
                 "Envelope %s in NodeSessionRequestHandler, requirements are satisfied!",
                 envelope.getId()));
 
-    envelope.put(Field.SESSION_LOOKUP, new SessionLookup(envelope.get(Field.NODE).getNodeId()));
+    envelope.put(Field.SESSION_LOOKUP, new SessionLookup(envelope.get(Field.NODE)));
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/SessionLookup.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/SessionLookup.java
@@ -3,13 +3,26 @@
  */
 package org.ethereum.beacon.discovery.pipeline.handler;
 
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
 
 public class SessionLookup {
+  private final Optional<NodeRecord> nodeRecord;
   private final Bytes nodeId;
 
+  public SessionLookup(final NodeRecord nodeRecord) {
+    this.nodeRecord = Optional.of(nodeRecord);
+    this.nodeId = nodeRecord.getNodeId();
+  }
+
   public SessionLookup(final Bytes nodeId) {
+    this.nodeRecord = Optional.empty();
     this.nodeId = nodeId;
+  }
+
+  public Optional<NodeRecord> getNodeRecord() {
+    return nodeRecord;
   }
 
   public Bytes getNodeId() {

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -89,7 +89,7 @@ public class DiscoveryIntegrationTest {
     assertTrue(pingResult.isDone());
     assertFalse(pingResult.isCompletedExceptionally());
 
-    final CompletableFuture<Void> findNodesResult =
+    final CompletableFuture<Collection<NodeRecord>> findNodesResult =
         client.findNodes(bootnode.getLocalNodeRecord(), singletonList(0));
     waitFor(findNodesResult);
     assertTrue(findNodesResult.isDone());

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -79,6 +79,23 @@ public class DiscoveryIntegrationTest {
   }
 
   @Test
+  public void shouldSuccessfullyCommunicateWithPreviouslyUnknownNode() throws Exception {
+    final DiscoverySystem bootnode = createDiscoveryClient();
+    final DiscoverySystem client = createDiscoveryClient();
+
+    final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
+    waitFor(pingResult);
+    assertTrue(pingResult.isDone());
+    assertFalse(pingResult.isCompletedExceptionally());
+
+    final CompletableFuture<Void> findNodesResult =
+        client.findNodes(bootnode.getLocalNodeRecord(), singletonList(0));
+    waitFor(findNodesResult);
+    assertTrue(findNodesResult.isDone());
+    assertFalse(findNodesResult.isCompletedExceptionally());
+  }
+
+  @Test
   public void shouldSuccessfullyUpdateCustomFieldValue() throws Exception {
     final String CUSTOM_FIELD_NAME = "custom_field_name";
     final Bytes CUSTOM_FIELD_VALUE = Bytes.fromHexString("0xdeadbeef");


### PR DESCRIPTION
## PR Description
Use the ENR supplied when initiating the request rather than requiring the peer to be present in the node table.
Still looks up the record from the node table if it is unknown (eg incoming requests).

Part of #111 