### PR TITLE
Return found nodes

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
@@ -4,6 +4,7 @@
 
 package org.ethereum.beacon.discovery;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.tuweni.bytes.Bytes;
@@ -31,7 +32,8 @@ public interface DiscoveryManager {
    * @return Future which is fired when reply is received or fails in timeout/not successful
    *     handshake/bad message exchange.
    */
-  CompletableFuture<Void> findNodes(NodeRecord nodeRecord, List<Integer> distances);
+  CompletableFuture<Collection<NodeRecord>> findNodes(
+      NodeRecord nodeRecord, List<Integer> distances);
 
   /**
    * Initiates PING with node `nodeRecord`

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -168,13 +169,14 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
   }
 
   @Override
-  public CompletableFuture<Void> findNodes(NodeRecord nodeRecord, List<Integer> distances) {
+  public CompletableFuture<Collection<NodeRecord>> findNodes(
+      NodeRecord nodeRecord, List<Integer> distances) {
     addNode(nodeRecord);
-    Request<Void> request =
+    Request<Collection<NodeRecord>> request =
         new Request<>(
             new CompletableFuture<>(),
             reqId -> new FindNodeMessage(reqId, distances),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(distances));
     return executeTaskImpl(nodeRecord, request);
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
@@ -3,6 +3,7 @@
  */
 package org.ethereum.beacon.discovery;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -73,9 +74,10 @@ public class DiscoverySystem {
    * @param nodeRecord Ethereum Node record
    * @param distances Distances to search for
    * @return Future which is fired when reply is received or fails in timeout/not successful
-   *     handshake/bad message exchange.
+   *     handshake/bad message exchange. Contains the collection of nodes returned by the peer.
    */
-  public CompletableFuture<Void> findNodes(NodeRecord nodeRecord, List<Integer> distances) {
+  public CompletableFuture<Collection<NodeRecord>> findNodes(
+      NodeRecord nodeRecord, List<Integer> distances) {
     return discoveryManager.findNodes(nodeRecord, distances);
   }
 
@@ -105,7 +107,7 @@ public class DiscoverySystem {
     return nodeTable.streamClosestNodes(Bytes32.ZERO, 0);
   }
 
-  public CompletableFuture<Void> searchForNewPeers() {
+  public CompletableFuture<Collection<NodeRecord>> searchForNewPeers() {
     return taskManager.searchForNewPeers();
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/NodesHandler.java
@@ -5,22 +5,13 @@
 package org.ethereum.beacon.discovery.message.handler;
 
 import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.tuweni.bytes.Bytes;
-import org.ethereum.beacon.discovery.message.FindNodeMessage;
 import org.ethereum.beacon.discovery.message.NodesMessage;
 import org.ethereum.beacon.discovery.pipeline.info.FindNodeResponseHandler;
 import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
-import org.ethereum.beacon.discovery.schema.NodeRecord;
-import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
-import org.ethereum.beacon.discovery.storage.NodeTable;
 import org.ethereum.beacon.discovery.task.TaskStatus;
-import org.ethereum.beacon.discovery.util.Functions;
 
 public class NodesHandler implements MessageHandler<NodesMessage> {
-  private static final Logger logger = LogManager.getLogger(NodesHandler.class);
 
   @Override
   public void handle(NodesMessage message, NodeSession session) {
@@ -36,66 +27,10 @@ public class NodesHandler implements MessageHandler<NodesMessage> {
     FindNodeResponseHandler respHandler =
         (FindNodeResponseHandler) requestInfo.getRequest().getResponseHandler();
 
-    if (respHandler.handleResponseMessage(message)) {
-      session.clearRequestInfo(message.getRequestId(), null);
+    if (respHandler.handleResponseMessage(message, session)) {
+      session.clearRequestInfo(message.getRequestId(), respHandler.getFoundNodes());
     } else {
-      requestInfo.setTaskStatus(TaskStatus.IN_PROCESS);
+      requestInfo.setTaskStatus(TaskStatus.IN_PROGRESS);
     }
-    // Parse node records
-    logger.trace(
-        () ->
-            String.format(
-                "Received %s node records in session %s. Total buckets expected: %s",
-                message.getNodeRecords().size(), session, message.getTotal()));
-    message.getNodeRecords().stream()
-        .filter(this::isValid)
-        .filter(
-            record ->
-                hasCorrectDistance(session, (FindNodeMessage) requestInfo.getMessage(), record))
-        .forEach(nodeRecordV5 -> updateNodeRecord(session, nodeRecordV5));
-  }
-
-  private void updateNodeRecord(final NodeSession session, final NodeRecord nodeRecordV5) {
-    NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeRecordV5);
-    final NodeTable nodeTable = session.getNodeTable();
-    final Bytes nodeId = nodeRecordV5.getNodeId();
-    final Optional<NodeRecordInfo> existingRecord = nodeTable.getNode(nodeId);
-    if (isUpdateRequired(nodeRecordV5, existingRecord)) {
-      // Update node table with new node record
-      nodeTable.save(nodeRecordInfo);
-
-      if (session.getNodeId().equals(nodeId)) {
-        // Node sent us a new version of their own ENR, update the session.
-        session.updateNodeRecord(nodeRecordV5);
-      }
-    }
-  }
-
-  private boolean isUpdateRequired(
-      final NodeRecord newRecord, final Optional<NodeRecordInfo> existingRecord) {
-    return existingRecord.isEmpty()
-        || existingRecord.get().getNode().getSeq().compareTo(newRecord.getSeq()) < 0;
-  }
-
-  private boolean isValid(final NodeRecord record) {
-    if (!record.isValid()) {
-      logger.debug("Rejecting invalid node record {}", record);
-      return false;
-    }
-    return true;
-  }
-
-  private boolean hasCorrectDistance(
-      final NodeSession session, final FindNodeMessage requestMsg, final NodeRecord nodeRecordV5) {
-    final int actualDistance = Functions.logDistance(nodeRecordV5.getNodeId(), session.getNodeId());
-    if (!requestMsg.getDistances().contains(actualDistance)) {
-      logger.debug(
-          "Rejecting node record {} received from {} because distance was not in {}.",
-          nodeRecordV5.getNodeId(),
-          session.getNodeId(),
-          requestMsg.getDistances());
-      return false;
-    }
-    return true;
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -3,30 +3,112 @@
  */
 package org.ethereum.beacon.discovery.pipeline.info;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.message.NodesMessage;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
+import org.ethereum.beacon.discovery.schema.NodeSession;
+import org.ethereum.beacon.discovery.storage.NodeTable;
+import org.ethereum.beacon.discovery.util.Functions;
 
 public class FindNodeResponseHandler implements MultiPacketResponseHandler<NodesMessage> {
+  private static final Logger logger = LogManager.getLogger(FindNodeResponseHandler.class);
   private static final int MAX_TOTAL_PACKETS = 16;
+  private final List<NodeRecord> foundNodes = new ArrayList<>();
+  private final Collection<Integer> distances;
   private int totalPackets = -1;
   private int receivedPackets = 0;
 
+  public FindNodeResponseHandler(final Collection<Integer> distances) {
+    this.distances = distances;
+  }
+
   @Override
-  public synchronized boolean handleResponseMessage(NodesMessage msg) {
+  public synchronized boolean handleResponseMessage(NodesMessage message, NodeSession session) {
     if (totalPackets == -1) {
-      totalPackets = msg.getTotal();
+      totalPackets = message.getTotal();
       if (totalPackets < 1 || totalPackets > MAX_TOTAL_PACKETS) {
         throw new RuntimeException("Invalid number of total packets: " + totalPackets);
       }
     } else {
-      if (totalPackets != msg.getTotal()) {
+      if (totalPackets != message.getTotal()) {
         throw new RuntimeException(
             "Total number differ in different packets for a single response: "
                 + totalPackets
                 + " != "
-                + msg.getTotal());
+                + message.getTotal());
       }
     }
     receivedPackets++;
+
+    // Parse node records
+    logger.trace(
+        () ->
+            String.format(
+                "Received %s node records in session %s. Total buckets expected: %s",
+                message.getNodeRecords().size(), session, message.getTotal()));
+    message.getNodeRecords().stream()
+        .filter(this::isValid)
+        .filter(record -> hasCorrectDistance(session, record))
+        .forEach(
+            nodeRecordV5 -> {
+              foundNodes.add(nodeRecordV5);
+              updateNodeRecord(session, nodeRecordV5);
+            });
+
     return receivedPackets >= totalPackets;
+  }
+
+  public synchronized List<NodeRecord> getFoundNodes() {
+    return foundNodes;
+  }
+
+  private void updateNodeRecord(final NodeSession session, final NodeRecord nodeRecordV5) {
+    NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeRecordV5);
+    final NodeTable nodeTable = session.getNodeTable();
+    final Bytes nodeId = nodeRecordV5.getNodeId();
+    final Optional<NodeRecordInfo> existingRecord = nodeTable.getNode(nodeId);
+    if (isUpdateRequired(nodeRecordV5, existingRecord)) {
+      // Update node table with new node record
+      nodeTable.save(nodeRecordInfo);
+
+      if (session.getNodeId().equals(nodeId)) {
+        // Node sent us a new version of their own ENR, update the session.
+        session.updateNodeRecord(nodeRecordV5);
+      }
+    }
+  }
+
+  private boolean isUpdateRequired(
+      final NodeRecord newRecord, final Optional<NodeRecordInfo> existingRecord) {
+    return existingRecord.isEmpty()
+        || existingRecord.get().getNode().getSeq().compareTo(newRecord.getSeq()) < 0;
+  }
+
+  private boolean isValid(final NodeRecord record) {
+    if (!record.isValid()) {
+      logger.debug("Rejecting invalid node record {}", record);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean hasCorrectDistance(final NodeSession session, final NodeRecord nodeRecordV5) {
+    final int actualDistance = Functions.logDistance(nodeRecordV5.getNodeId(), session.getNodeId());
+    if (!distances.contains(actualDistance)) {
+      logger.debug(
+          "Rejecting node record {} received from {} because distance was not in {}.",
+          nodeRecordV5.getNodeId(),
+          session.getNodeId(),
+          distances);
+      return false;
+    }
+    return true;
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/MultiPacketResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/MultiPacketResponseHandler.java
@@ -4,15 +4,16 @@
 package org.ethereum.beacon.discovery.pipeline.info;
 
 import org.ethereum.beacon.discovery.message.V5Message;
+import org.ethereum.beacon.discovery.schema.NodeSession;
 
 public interface MultiPacketResponseHandler<TMessageType extends V5Message> {
 
-  MultiPacketResponseHandler<?> SINGLE_PACKET_RESPONSE_HANDLER = __ -> true;
+  MultiPacketResponseHandler<?> SINGLE_PACKET_RESPONSE_HANDLER = (msg, session) -> true;
 
   /**
    * Handle next packet in a single response
    *
    * @return true if all expected packets are received, false otherwise
    */
-  boolean handleResponseMessage(TMessageType msg);
+  boolean handleResponseMessage(TMessageType msg, NodeSession session);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
@@ -7,6 +7,7 @@ package org.ethereum.beacon.discovery.task;
 import static org.ethereum.beacon.discovery.schema.NodeStatus.DEAD;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -228,20 +229,20 @@ public class DiscoveryTaskManager {
                                 (nodeRecord.getRetry() + 1)))));
   }
 
-  public CompletableFuture<Void> searchForNewPeers() {
+  public CompletableFuture<Collection<NodeRecord>> searchForNewPeers() {
     // We wind up with a CompletableFuture<CompletableFuture> so unwrap one level.
     return scheduler.execute(this::performSearchForNewPeers).thenCompose(Function.identity());
   }
 
-  private CompletableFuture<Void> performSearchForNewPeers() {
+  private CompletableFuture<Collection<NodeRecord>> performSearchForNewPeers() {
     return new RecursiveLookupTask(
             nodeTable, this::findNodes, RECURSIVE_SEARCH_QUERY_LIMIT, Bytes32.random())
         .execute();
   }
 
-  private CompletableFuture<Void> findNodes(
+  private CompletableFuture<Collection<NodeRecord>> findNodes(
       final NodeRecordInfo nodeRecordInfo, final int distance) {
-    final CompletableFuture<Void> searchResult =
+    final CompletableFuture<Collection<NodeRecord>> searchResult =
         recursiveLookupTasks.add(nodeRecordInfo.getNode(), distance);
     searchResult.handle(
         (__, error) -> {

--- a/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTasks.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTasks.java
@@ -7,6 +7,7 @@ package org.ethereum.beacon.discovery.task;
 import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -40,31 +41,31 @@ public class RecursiveLookupTasks {
         expirationSchedulerFactory.create(timeout.get(ChronoUnit.SECONDS), TimeUnit.SECONDS);
   }
 
-  public CompletableFuture<Void> add(NodeRecord nodeRecord, int distance) {
+  public CompletableFuture<Collection<NodeRecord>> add(NodeRecord nodeRecord, int distance) {
     if (!currentTasks.add(nodeRecord.getNodeId())) {
       return CompletableFuture.failedFuture(new IllegalStateException("Already querying node"));
     }
 
-    final CompletableFuture<Void> result = new CompletableFuture<>();
+    final CompletableFuture<Collection<NodeRecord>> result = new CompletableFuture<>();
     scheduler.execute(
         () -> {
-          CompletableFuture<Void> request =
+          CompletableFuture<Collection<NodeRecord>> request =
               discoveryManager.findNodes(nodeRecord, Collections.singletonList(distance));
           addTimeout(nodeRecord, request);
           request.whenComplete(
-              (aVoid, throwable) -> {
+              (foundNodes, throwable) -> {
                 currentTasks.remove(nodeRecord.getNodeId());
                 if (throwable != null) {
                   result.completeExceptionally(throwable);
                 } else {
-                  result.complete(null);
+                  result.complete(foundNodes);
                 }
               });
         });
     return result;
   }
 
-  private void addTimeout(final NodeRecord nodeRecord, final CompletableFuture<Void> retry) {
+  private void addTimeout(final NodeRecord nodeRecord, final CompletableFuture<?> retry) {
     taskTimeouts.put(
         nodeRecord.getNodeId(),
         () ->

--- a/src/main/java/org/ethereum/beacon/discovery/task/TaskStatus.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/TaskStatus.java
@@ -7,6 +7,6 @@ package org.ethereum.beacon.discovery.task;
 public enum TaskStatus {
   AWAIT, // waiting for handshake or whatever
   SENT, // request sent
-  IN_PROCESS, // reply should contain several messages, at least one received but not all
+  IN_PROGRESS, // reply should contain several messages, at least one received but not all
   // XXX: completed task is not stored, so no status for completed
 }

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -172,7 +172,7 @@ public class HandshakeHandlersTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(1)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(1)));
     nodeSessionAt1For2.createNextRequest(request);
 
     RawPacket whoAreYouRawPacket = outgoing2Packets.poll(1, TimeUnit.SECONDS);

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -114,26 +114,6 @@ public class DiscoveryIntegrationTest {
   }
 
   @Test
-  public void shouldReturnNodesFoundByFindNodesRequest() throws Exception {
-    final DiscoverySystem bootnode = createDiscoveryClient();
-    final DiscoverySystem client = createDiscoveryClient(bootnode.getLocalNodeRecord());
-    final DiscoverySystem otherNode = createDiscoveryClient(bootnode.getLocalNodeRecord());
-    final Bytes clientNodeId = client.getLocalNodeRecord().getNodeId();
-    final int distance =
-        Functions.logDistance(clientNodeId, otherNode.getLocalNodeRecord().getNodeId());
-    waitFor(otherNode.ping(bootnode.getLocalNodeRecord()));
-    waitFor(client.ping(bootnode.getLocalNodeRecord()));
-    waitFor(bootnode.ping(otherNode.getLocalNodeRecord()));
-
-    // Find nodes at a distance we know has a node record to return.
-    final CompletableFuture<Collection<NodeRecord>> findNodesResult =
-        client.findNodes(bootnode.getLocalNodeRecord(), singletonList(distance));
-    final Collection<NodeRecord> foundNodes = waitFor(findNodesResult);
-    assertTrue(findNodesResult.isDone());
-    assertThat(foundNodes).contains(otherNode.getLocalNodeRecord());
-  }
-
-  @Test
   public void shouldNotSuccessfullyPingBootnodeWhenNodeRecordIsNotSigned() throws Exception {
     final DiscoverySystem bootnode = createDiscoveryClient();
     final DiscoverySystem client = createDiscoveryClient(false, bootnode.getLocalNodeRecord());

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -390,12 +390,12 @@ public class DiscoveryIntegrationTest {
     throw new IllegalStateException("Could not find a free port after multiple attempts");
   }
 
-  private <T> T waitFor(final CompletableFuture<T> future) throws Exception {
-    return waitFor(future, 30);
+  private void waitFor(final CompletableFuture<?> future) throws Exception {
+    waitFor(future, 30);
   }
 
-  private <T> T waitFor(final CompletableFuture<T> future, final int timeout) throws Exception {
-    return future.get(timeout, TimeUnit.SECONDS);
+  private void waitFor(final CompletableFuture<?> future, final int timeout) throws Exception {
+    future.get(timeout, TimeUnit.SECONDS);
   }
 
   private void waitFor(final ThrowingRunnable assertion) throws Exception {

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.ethereum.beacon.discovery.message.handler;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.Assertions;
+import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
+import org.ethereum.beacon.discovery.message.FindNodeMessage;
+import org.ethereum.beacon.discovery.message.NodesMessage;
+import org.ethereum.beacon.discovery.pipeline.info.FindNodeResponseHandler;
+import org.ethereum.beacon.discovery.pipeline.info.Request;
+import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeSession;
+import org.ethereum.beacon.discovery.storage.NodeTable;
+import org.ethereum.beacon.discovery.task.TaskStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NodesHandlerTest {
+
+  private static final Bytes PEER_ID = Bytes.fromHexString("0x1234567890ABCDEF");
+  private static final Bytes REQUEST_ID = Bytes.fromHexString("0x1234");
+  private final NodeSession session = mock(NodeSession.class);
+  private final NodeTable nodeTable = mock(NodeTable.class);
+  private final FindNodeResponseHandler responseHandler = mock(FindNodeResponseHandler.class);
+  private final Request<Void> request =
+      new Request<>(
+          new CompletableFuture<>(),
+          id -> new FindNodeMessage(id, singletonList(1)),
+          responseHandler);
+  private final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
+
+  private final NodesHandler handler = new NodesHandler();
+
+  @BeforeEach
+  public void setUp() {
+    when(session.getNodeTable()).thenReturn(nodeTable);
+    when(session.getNodeId()).thenReturn(PEER_ID);
+
+    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+  }
+
+  @Test
+  void shouldFailWhenRequestIsUnknown() {
+    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.empty());
+
+    final NodesMessage message = new NodesMessage(REQUEST_ID, 0, emptyList());
+    Assertions.assertThatThrownBy(() -> handler.handle(message, session))
+        .hasMessageContaining("not found in session");
+  }
+
+  @Test
+  void shouldClearRequestWhenResponseHandlerIndicatesResponseComplete() {
+    final List<NodeRecord> foundNodes =
+        List.of(SimpleIdentitySchemaInterpreter.createNodeRecord(2));
+    final NodesMessage message = new NodesMessage(REQUEST_ID, 0, emptyList());
+    when(responseHandler.handleResponseMessage(message, session)).thenReturn(true);
+    when(responseHandler.getFoundNodes()).thenReturn(foundNodes);
+
+    handler.handle(message, session);
+
+    verify(session).clearRequestInfo(REQUEST_ID, foundNodes);
+  }
+
+  @Test
+  void shouldUpdateRequestStatusWhenResponseHandlerIndicatesResponseIncomplete() {
+    final List<NodeRecord> foundNodes =
+        List.of(SimpleIdentitySchemaInterpreter.createNodeRecord(2));
+    final NodesMessage message = new NodesMessage(REQUEST_ID, 0, emptyList());
+    when(responseHandler.handleResponseMessage(message, session)).thenReturn(false);
+    when(responseHandler.getFoundNodes()).thenReturn(foundNodes);
+
+    handler.handle(message, session);
+
+    verify(session, never()).clearRequestInfo(any(), any());
+    assertThat(requestInfo.getTaskStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/NodesHandlerTest.java
@@ -53,7 +53,7 @@ class NodesHandlerTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(distance)));
     final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
     when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
@@ -77,7 +77,7 @@ class NodesHandlerTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(distance)));
     final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
     when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
 
@@ -105,7 +105,7 @@ class NodesHandlerTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(0)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(0)));
     final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
     when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
     // Requesting from the node itself
@@ -133,7 +133,7 @@ class NodesHandlerTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(distance)));
     final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
     when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
@@ -151,7 +151,7 @@ class NodesHandlerTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(distance - 1)),
-            new FindNodeResponseHandler());
+            new FindNodeResponseHandler(singletonList(distance)));
     final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
     when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandlerTest.java
@@ -1,10 +1,10 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  */
-
-package org.ethereum.beacon.discovery.message.handler;
+package org.ethereum.beacon.discovery.pipeline.info;
 
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,15 +14,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.TestUtil;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
-import org.ethereum.beacon.discovery.message.FindNodeMessage;
 import org.ethereum.beacon.discovery.message.NodesMessage;
-import org.ethereum.beacon.discovery.pipeline.info.FindNodeResponseHandler;
-import org.ethereum.beacon.discovery.pipeline.info.Request;
-import org.ethereum.beacon.discovery.pipeline.info.RequestInfo;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordInfo;
 import org.ethereum.beacon.discovery.schema.NodeSession;
@@ -31,13 +26,11 @@ import org.ethereum.beacon.discovery.util.Functions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class NodesHandlerTest {
-
+class FindNodeResponseHandlerTest {
   private static final Bytes PEER_ID = Bytes.fromHexString("0x1234567890ABCDEF");
   private static final Bytes REQUEST_ID = Bytes.fromHexString("0x1234");
   private final NodeSession session = mock(NodeSession.class);
   private final NodeTable nodeTable = mock(NodeTable.class);
-  private final NodesHandler handler = new NodesHandler();
 
   @BeforeEach
   public void setUp() {
@@ -49,21 +42,15 @@ class NodesHandlerTest {
   public void shouldAddReceivedRecordsToNodeTableButNotNodeBuckets() {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
-    Request<Void> request =
-        new Request<>(
-            new CompletableFuture<>(),
-            id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler(singletonList(distance)));
-    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
-    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(distance));
+
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
-    handler.handle(message, session);
+    assertThat(handler.handleResponseMessage(message, session)).isTrue();
 
     final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(nodeInfo.getNodeRecord());
     verify(nodeTable).save(nodeRecordInfo);
     verify(session, never()).putRecordInBucket(nodeRecordInfo);
-    verify(session).clearRequestInfo(REQUEST_ID, null);
   }
 
   @Test
@@ -73,26 +60,19 @@ class NodesHandlerTest {
     when(nodeTable.getNode(originalRecord.getNodeId()))
         .thenReturn(Optional.of(NodeRecordInfo.createDefault(originalRecord)));
     final int distance = Functions.logDistance(PEER_ID, originalRecord.getNodeId());
-    Request<Void> request =
-        new Request<>(
-            new CompletableFuture<>(),
-            id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler(singletonList(distance)));
-    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
-    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(distance));
 
     final NodeRecord updatedRecord =
         originalRecord.withUpdatedCustomField(
             "test", Bytes.fromHexString("0x8888"), nodeInfo.getPrivateKey());
     final List<NodeRecord> records = singletonList(updatedRecord);
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
-    handler.handle(message, session);
+    assertThat(handler.handleResponseMessage(message, session)).isTrue();
 
     final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(updatedRecord);
     verify(nodeTable).save(nodeRecordInfo);
     verify(session, never()).updateNodeRecord(any());
     verify(session, never()).putRecordInBucket(any());
-    verify(session).clearRequestInfo(REQUEST_ID, null);
   }
 
   @Test
@@ -101,13 +81,7 @@ class NodesHandlerTest {
     final NodeRecord originalRecord = nodeInfo.getNodeRecord();
     when(nodeTable.getNode(originalRecord.getNodeId()))
         .thenReturn(Optional.of(NodeRecordInfo.createDefault(originalRecord)));
-    Request<Void> request =
-        new Request<>(
-            new CompletableFuture<>(),
-            id -> new FindNodeMessage(id, singletonList(0)),
-            new FindNodeResponseHandler(singletonList(0)));
-    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
-    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(0));
     // Requesting from the node itself
     when(session.getNodeId()).thenReturn(originalRecord.getNodeId());
 
@@ -116,29 +90,22 @@ class NodesHandlerTest {
             "test", Bytes.fromHexString("0x8888"), nodeInfo.getPrivateKey());
     final List<NodeRecord> records = singletonList(updatedRecord);
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
-    handler.handle(message, session);
+    handler.handleResponseMessage(message, session);
 
     final NodeRecordInfo nodeRecordInfo = NodeRecordInfo.createDefault(updatedRecord);
     verify(nodeTable).save(nodeRecordInfo);
     verify(session).updateNodeRecord(updatedRecord);
     verify(session, never()).putRecordInBucket(any());
-    verify(session).clearRequestInfo(REQUEST_ID, null);
   }
 
   @Test
   public void shouldRejectReceivedRecordsThatAreInvalid() {
     final NodeInfo nodeInfo = TestUtil.generateInvalidNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
-    Request<Void> request =
-        new Request<>(
-            new CompletableFuture<>(),
-            id -> new FindNodeMessage(id, singletonList(distance)),
-            new FindNodeResponseHandler(singletonList(distance)));
-    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
-    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(distance));
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
-    handler.handle(message, session);
+    handler.handleResponseMessage(message, session);
 
     verifyNoInteractions(nodeTable);
   }
@@ -147,16 +114,11 @@ class NodesHandlerTest {
   public void shouldRejectReceivedRecordsThatAreNotAtCorrectDistance() {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
-    Request<Void> request =
-        new Request<>(
-            new CompletableFuture<>(),
-            id -> new FindNodeMessage(id, singletonList(distance - 1)),
-            new FindNodeResponseHandler(singletonList(distance)));
-    final RequestInfo requestInfo = RequestInfo.create(REQUEST_ID, request);
-    when(session.getRequestInfo(REQUEST_ID)).thenReturn(Optional.of(requestInfo));
+    final FindNodeResponseHandler handler =
+        new FindNodeResponseHandler(singletonList(distance + 1));
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
-    handler.handle(message, session);
+    handler.handleResponseMessage(message, session);
 
     verifyNoInteractions(nodeTable);
   }


### PR DESCRIPTION
## PR Description
Return the nodes found by a `findNodes` or `searchForNewPeers` request so they can be utilised even if they didn't get added to the node table (eg because it was full).