### PR TITLE
During recursive lookups, use nodes found by previous requests when selecting next source

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
@@ -241,7 +241,7 @@ public class DiscoveryTaskManager {
 
   private CompletableFuture<Collection<NodeRecord>> performSearchForNewPeers() {
     return new RecursiveLookupTask(
-            nodeTable, this::findNodes, RECURSIVE_SEARCH_QUERY_LIMIT, Bytes32.random())
+            nodeTable, this::findNodes, RECURSIVE_SEARCH_QUERY_LIMIT, Bytes32.random(), homeNodeId)
         .execute();
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTask.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTask.java
@@ -52,7 +52,7 @@ public class RecursiveLookupTask {
             .reversed()
             .thenComparing(NodeRecord::getNodeId);
     this.foundNodes = new TreeSet<>(distanceComparator);
-    // Don't query ourselves
+    // Don't query ourselves, even if our record is returned by one of the queries
     this.queriedNodeIds.add(homeNodeId);
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTask.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/RecursiveLookupTask.java
@@ -6,10 +6,15 @@ package org.ethereum.beacon.discovery.task;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -21,24 +26,34 @@ import org.ethereum.beacon.discovery.util.Functions;
 public class RecursiveLookupTask {
   private static final Logger LOG = LogManager.getLogger();
   private static final int MAX_CONCURRENT_QUERIES = 3;
-  private final NodeTable nodeTable;
   private final FindNodesAction sendFindNodesRequest;
   private final Bytes targetNodeId;
   private final Set<Bytes> queriedNodeIds = new HashSet<>();
+  private final Comparator<NodeRecord> distanceComparator;
+  private final NodeTable nodeTable;
   private int availableQuerySlots = MAX_CONCURRENT_QUERIES;
   private int remainingTotalQueryLimit;
   private final CompletableFuture<Collection<NodeRecord>> future = new CompletableFuture<>();
-  private final Set<NodeRecord> foundNodes = new HashSet<>();
+  private final NavigableSet<NodeRecord> foundNodes;
 
   public RecursiveLookupTask(
       final NodeTable nodeTable,
       final FindNodesAction sendFindNodesRequest,
       final int totalQueryLimit,
-      final Bytes targetNodeId) {
+      final Bytes targetNodeId,
+      final Bytes homeNodeId) {
     this.nodeTable = nodeTable;
     this.sendFindNodesRequest = sendFindNodesRequest;
     this.remainingTotalQueryLimit = totalQueryLimit;
     this.targetNodeId = targetNodeId;
+    this.distanceComparator =
+        Comparator.<NodeRecord, BigInteger>comparing(
+                node -> Functions.distance(targetNodeId, node.getNodeId()))
+            .reversed()
+            .thenComparing(NodeRecord::getNodeId);
+    this.foundNodes = new TreeSet<>(distanceComparator);
+    // Don't query ourselves
+    this.queriedNodeIds.add(homeNodeId);
   }
 
   public CompletableFuture<Collection<NodeRecord>> execute() {
@@ -55,10 +70,14 @@ public class RecursiveLookupTask {
       future.complete(foundNodes);
       return;
     }
-    nodeTable
-        .streamClosestNodes(targetNodeId, 0)
-        .filter(DiscoveryTaskManager.RECURSIVE_LOOKUP_NODE_RULE)
-        .filter(record -> !queriedNodeIds.contains(record.getNode().getNodeId()))
+    final Stream<NodeRecordInfo> closestNodesFromBuckets =
+        nodeTable
+            .streamClosestNodes(targetNodeId, 0)
+            .filter(DiscoveryTaskManager.RECURSIVE_LOOKUP_NODE_RULE)
+            .filter(node -> !queriedNodeIds.contains(node.getNode().getNodeId()))
+            .limit(Math.min(availableQuerySlots, remainingTotalQueryLimit));
+    Stream.concat(closestNodesFromBuckets, foundNodes.stream().map(NodeRecordInfo::createDefault))
+        .sorted((o1, o2) -> distanceComparator.compare(o1.getNode(), o2.getNode()))
         .limit(Math.min(availableQuerySlots, remainingTotalQueryLimit))
         .forEach(this::queryPeer);
     if (availableQuerySlots == MAX_CONCURRENT_QUERIES) {
@@ -75,12 +94,13 @@ public class RecursiveLookupTask {
     sendFindNodesRequest
         .findNodes(peer, Functions.logDistance(peer.getNode().getNodeId(), targetNodeId))
         .whenComplete(
-            (__, error) -> {
+            (nodes, error) -> {
               if (error != null) {
                 LOG.debug("Failed to query " + peer.getNode().getNodeId(), error);
               }
               synchronized (RecursiveLookupTask.this) {
                 availableQuerySlots++;
+                foundNodes.addAll(nodes);
                 sendRequests();
               }
             });

--- a/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
@@ -11,6 +11,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.math.BigInteger;
+import java.nio.ByteOrder;
 import java.security.SecureRandom;
 import java.util.Random;
 import org.apache.logging.log4j.LogManager;
@@ -230,6 +231,10 @@ public class Functions {
       }
     }
     return logDistance;
+  }
+
+  public static BigInteger distance(Bytes nodeId1, Bytes nodeId2) {
+    return nodeId1.xor(nodeId2).toUnsignedBigInteger(ByteOrder.LITTLE_ENDIAN);
   }
 
   /**

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -203,11 +203,8 @@ public class DiscoveryIntegrationTest {
         waitFor(localNode.ping(remoteNodeRecords[i]));
       } catch (final Throwable t) {
         fail(
-            new Exception(
-                "Failed to ping node "
-                    + i
-                    + "  Local node seqNum: "
-                    + localNode.getLocalNodeRecord()));
+            "Failed to ping node " + i + "  Local node seqNum: " + localNode.getLocalNodeRecord(),
+            t);
       }
     }
 

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.BindException;
 import java.net.InetAddress;
@@ -196,23 +195,15 @@ public class DiscoveryIntegrationTest {
 
     final DiscoverySystem localNode = createDiscoveryClient("0.0.0.0", remoteNodeRecords);
 
-    for (int i = 0, remoteNodeRecordsLength = remoteNodeRecords.length;
-        i < remoteNodeRecordsLength;
-        i++) {
-      try {
-        waitFor(localNode.ping(remoteNodeRecords[i]));
-      } catch (final Throwable t) {
-        fail(
-            "Failed to ping node " + i + "  Local node seqNum: " + localNode.getLocalNodeRecord(),
-            t);
-      }
-    }
-
-    // Address should have been updated. Most likely to 127.0.0.1 but it might be something else
-    // if the system is configured unusually or uses IPv6 in preference to v4.
-    final InetAddress updatedAddress =
-        localNode.getLocalNodeRecord().getUdpAddress().orElseThrow().getAddress();
-    assertThat(updatedAddress).isNotEqualTo(InetAddress.getByName("0.0.0.0"));
+    // Address should have been updated by automatically pinging the bootnodes.
+    // Most likely to 127.0.0.1 but it might be something else if the system is configured unusually
+    // or uses IPv6 in preference to v4.
+    waitFor(
+        () -> {
+          final InetAddress updatedAddress =
+              localNode.getLocalNodeRecord().getUdpAddress().orElseThrow().getAddress();
+          assertThat(updatedAddress).isNotEqualTo(InetAddress.getByName("0.0.0.0"));
+        });
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/task/RecursiveLookupTaskTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/task/RecursiveLookupTaskTest.java
@@ -64,7 +64,7 @@ class RecursiveLookupTaskTest {
       new HashMap<>();
 
   private final RecursiveLookupTask task =
-      new RecursiveLookupTask(nodeTable, findNodesAction, 4, TARGET);
+      new RecursiveLookupTask(nodeTable, findNodesAction, 4, TARGET, Bytes.fromHexString("0xABCD"));
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
## PR Description
During a recursive lookup, include nodes found by previous requests in the search in the list of sources to consider for the next round of requests.  This enables the actual recursive lookup behaviour, rather than only querying existing nodes we know about (and have previously pinged). As a result, we wind up gradually getting closer to the target node ID rather than gradually querying nodes further and further away (because we start from the closest we already know about and never request from the same node twice).

While the newly discovered nodes may not respond (we haven't seen a ping from them), if they do they can be immediately added to our buckets and if not the search will just move on to a different node.