### PR TITLE
Give the NewAddressHandler more flexibilty in how it updates the node record

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -48,7 +48,7 @@ public class DiscoverySystemBuilder {
   private final NodeRecordFactory nodeRecordFactory = NodeRecordFactory.DEFAULT;
   private Schedulers schedulers;
   private NodeRecordListener localNodeRecordListener = NodeRecordListener.NOOP;
-  private NewAddressHandler newAddressHandler = NewAddressHandler.NOOP;
+  private NewAddressHandler newAddressHandler;
   private Duration retryTimeout = DiscoveryTaskManager.DEFAULT_RETRY_TIMEOUT;
   private Duration lifeCheckInterval = DiscoveryTaskManager.DEFAULT_LIVE_CHECK_INTERVAL;
   private int trafficReadLimit = 250000; // bytes per sec
@@ -131,6 +131,16 @@ public class DiscoverySystemBuilder {
   }
 
   private void createDefaults() {
+    newAddressHandler =
+        requireNonNullElseGet(
+            newAddressHandler,
+            () ->
+                (oldRecord, newAddress) ->
+                    Optional.of(
+                        oldRecord.withNewAddress(
+                            newAddress,
+                            oldRecord.getTcpAddress().map(InetSocketAddress::getPort),
+                            privateKey)));
     schedulers = requireNonNullElseGet(schedulers, Schedulers::createDefault);
     final InetSocketAddress serverListenAddress =
         listenAddress

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
@@ -40,7 +40,10 @@ public interface IdentitySchemaInterpreter {
   Optional<InetSocketAddress> getTcpAddress(NodeRecord nodeRecord);
 
   NodeRecord createWithNewAddress(
-      NodeRecord nodeRecord, InetSocketAddress newAddress, Bytes privateKey);
+      NodeRecord nodeRecord,
+      InetSocketAddress newAddress,
+      Optional<Integer> newTcpPort,
+      Bytes privateKey);
 
   NodeRecord createWithUpdatedCustomField(
       NodeRecord nodeRecord, String newAddress, Bytes value, Bytes privateKey);

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
@@ -89,11 +89,15 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
 
   @Override
   public NodeRecord createWithNewAddress(
-      final NodeRecord nodeRecord, final InetSocketAddress newAddress, final Bytes privateKey) {
+      final NodeRecord nodeRecord,
+      final InetSocketAddress newAddress,
+      final Optional<Integer> newTcpPort,
+      final Bytes privateKey) {
     final List<EnrField> fields =
         getAllFieldsThatMatch(nodeRecord, field -> !ADDRESS_FIELD_NAMES.contains(field.getName()));
 
-    NodeRecordBuilder.addFieldsForUdpAddress(fields, newAddress.getAddress(), newAddress.getPort());
+    NodeRecordBuilder.addFieldsForAddress(
+        fields, newAddress.getAddress(), newAddress.getPort(), newTcpPort);
     final NodeRecord newRecord = NodeRecord.fromValues(this, nodeRecord.getSeq().add(1), fields);
     sign(newRecord, privateKey);
     return newRecord;

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -206,8 +206,12 @@ public class NodeRecord {
     return identitySchemaInterpreter.getUdpAddress(this);
   }
 
-  public NodeRecord withNewAddress(final InetSocketAddress newAddress, final Bytes privateKey) {
-    return identitySchemaInterpreter.createWithNewAddress(this, newAddress, privateKey);
+  public NodeRecord withNewAddress(
+      final InetSocketAddress newUdpAddress,
+      final Optional<Integer> newTcpPort,
+      final Bytes privateKey) {
+    return identitySchemaInterpreter.createWithNewAddress(
+        this, newUdpAddress, newTcpPort, privateKey);
   }
 
   public NodeRecord withUpdatedCustomField(

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordBuilder.java
@@ -54,8 +54,7 @@ public class NodeRecordBuilder {
   public NodeRecordBuilder address(final String ipAddress, final int udpPort, final int tcpPort) {
     try {
       final InetAddress inetAddress = InetAddress.getByName(ipAddress);
-      addFieldsForUdpAddress(fields, inetAddress, udpPort);
-      fields.add(new EnrField(EnrField.TCP, tcpPort));
+      addFieldsForAddress(fields, inetAddress, udpPort, Optional.of(tcpPort));
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Unable to resolve address: " + ipAddress);
     }
@@ -67,12 +66,17 @@ public class NodeRecordBuilder {
     return this;
   }
 
-  static void addFieldsForUdpAddress(
-      final List<EnrField> fields, final InetAddress inetAddress, final int udpPort) {
+  static void addFieldsForAddress(
+      final List<EnrField> fields,
+      final InetAddress inetAddress,
+      final int udpPort,
+      final Optional<Integer> newTcpPort) {
     final Bytes address = Bytes.wrap(inetAddress.getAddress());
     final boolean isIpV6 = inetAddress instanceof Inet6Address;
     fields.add(new EnrField(isIpV6 ? EnrField.IP_V6 : EnrField.IP_V4, address));
     fields.add(new EnrField(isIpV6 ? EnrField.UDP_V6 : EnrField.UDP, udpPort));
+    newTcpPort.ifPresent(
+        tcpPort -> fields.add(new EnrField(isIpV6 ? EnrField.TCP_V6 : EnrField.TCP, tcpPort)));
   }
 
   static void addCustomField(

--- a/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
@@ -32,9 +32,8 @@ public class LocalNodeRecordStore {
 
   public void onSocketAddressChanged(final InetSocketAddress newAddress) {
     NodeRecord oldRecord = this.latestRecord;
-    NodeRecord proposedNewRecord = oldRecord.withNewAddress(newAddress, privateKey);
     newAddressHandler
-        .newAddress(oldRecord, proposedNewRecord)
+        .newAddress(oldRecord, newAddress)
         .ifPresent(
             record -> {
               this.latestRecord = record;

--- a/src/main/java/org/ethereum/beacon/discovery/storage/NewAddressHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/NewAddressHandler.java
@@ -4,13 +4,14 @@
 
 package org.ethereum.beacon.discovery.storage;
 
+import java.net.InetSocketAddress;
 import java.util.Optional;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 
 /** Listens for a node record updates */
 public interface NewAddressHandler {
 
-  NewAddressHandler NOOP = (oldVal, newVal) -> Optional.of(newVal);
+  NewAddressHandler NOOP = (oldRecord, newAddress) -> Optional.empty();
 
-  Optional<NodeRecord> newAddress(NodeRecord oldRecord, NodeRecord proposedRecord);
+  Optional<NodeRecord> newAddress(NodeRecord oldRecord, InetSocketAddress newAddress);
 }

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -78,7 +78,10 @@ public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterprete
 
   @Override
   public NodeRecord createWithNewAddress(
-      final NodeRecord nodeRecord, final InetSocketAddress newAddress, final Bytes privateKey) {
+      final NodeRecord nodeRecord,
+      final InetSocketAddress newAddress,
+      final Optional<Integer> newTcpPort,
+      final Bytes privateKey) {
     final NodeRecord newRecord = createNodeRecord(getNodeId(nodeRecord), newAddress);
     sign(newRecord, privateKey);
     return newRecord;

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -18,8 +18,13 @@ import org.ethereum.beacon.discovery.schema.IdentitySchema;
 import org.ethereum.beacon.discovery.schema.IdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.storage.NewAddressHandler;
 
 public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterpreter {
+
+  public static final NewAddressHandler ADDRESS_UPDATER =
+      (oldRecord, newAddress) ->
+          Optional.of(oldRecord.withNewAddress(newAddress, Optional.empty(), null));
 
   public static NodeRecord createNodeRecord(final int nodeId) {
     return createNodeRecord(Bytes.ofUnsignedInt(nodeId));

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
@@ -28,9 +28,13 @@ class ExternalAddressSelectorTest {
   private final Bytes nodeId = Bytes.fromHexString("0x1234567890");
   private final NodeRecord originalNodeRecord =
       SimpleIdentitySchemaInterpreter.createNodeRecord(nodeId, ADDRESS1);
+
+  private final NewAddressHandler newAddressHandler =
+      (oldRecord, newAddress) ->
+          Optional.of(oldRecord.withNewAddress(newAddress, Optional.empty(), null));
   private final LocalNodeRecordStore localNodeRecordStore =
       new LocalNodeRecordStore(
-          originalNodeRecord, nodeId, NodeRecordListener.NOOP, NewAddressHandler.NOOP);
+          originalNodeRecord, nodeId, NodeRecordListener.NOOP, newAddressHandler);
 
   private final ExternalAddressSelector selector =
       new ExternalAddressSelector(localNodeRecordStore);

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelectorTest.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery.message.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter.ADDRESS_UPDATER;
 import static org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector.MIN_CONFIRMATIONS;
 
 import java.net.InetSocketAddress;
@@ -14,7 +15,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
-import org.ethereum.beacon.discovery.storage.NewAddressHandler;
 import org.ethereum.beacon.discovery.storage.NodeRecordListener;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -29,12 +29,9 @@ class ExternalAddressSelectorTest {
   private final NodeRecord originalNodeRecord =
       SimpleIdentitySchemaInterpreter.createNodeRecord(nodeId, ADDRESS1);
 
-  private final NewAddressHandler newAddressHandler =
-      (oldRecord, newAddress) ->
-          Optional.of(oldRecord.withNewAddress(newAddress, Optional.empty(), null));
   private final LocalNodeRecordStore localNodeRecordStore =
       new LocalNodeRecordStore(
-          originalNodeRecord, nodeId, NodeRecordListener.NOOP, newAddressHandler);
+          originalNodeRecord, nodeId, NodeRecordListener.NOOP, ADDRESS_UPDATER);
 
   private final ExternalAddressSelector selector =
       new ExternalAddressSelector(localNodeRecordStore);

--- a/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
@@ -160,9 +160,12 @@ class IdentitySchemaV4InterpreterTest {
             new EnrField(EnrField.UDP, 3030));
     final InetSocketAddress newSocketAddress = new InetSocketAddress("127.0.0.1", 40404);
     final NodeRecord newRecord =
-        interpreter.createWithNewAddress(initialRecord, newSocketAddress, PRIV_KEY);
+        interpreter.createWithNewAddress(
+            initialRecord, newSocketAddress, Optional.of(5667), PRIV_KEY);
 
     assertThat(newRecord.getUdpAddress()).contains(newSocketAddress);
+    assertThat(newRecord.getTcpAddress())
+        .contains(new InetSocketAddress(newSocketAddress.getAddress(), 5667));
     assertThat(newRecord.get(EnrField.IP_V4))
         .isEqualTo(Bytes.wrap(newSocketAddress.getAddress().getAddress()));
   }
@@ -196,9 +199,12 @@ class IdentitySchemaV4InterpreterTest {
     final InetSocketAddress newSocketAddress =
         new InetSocketAddress(InetAddress.getByAddress(IPV6_LOCALHOST.toArrayUnsafe()), 40404);
     final NodeRecord newRecord =
-        interpreter.createWithNewAddress(initialRecord, newSocketAddress, PRIV_KEY);
+        interpreter.createWithNewAddress(
+            initialRecord, newSocketAddress, Optional.of(5667), PRIV_KEY);
 
     assertThat(newRecord.getUdpAddress()).contains(newSocketAddress);
+    assertThat(newRecord.getTcpAddress())
+        .contains(new InetSocketAddress(newSocketAddress.getAddress(), 5667));
     assertThat(newRecord.get(EnrField.IP_V6)).isEqualTo(IPV6_LOCALHOST);
   }
 
@@ -211,9 +217,12 @@ class IdentitySchemaV4InterpreterTest {
     final InetSocketAddress newSocketAddress =
         new InetSocketAddress(InetAddress.getByAddress(IPV6_LOCALHOST.toArrayUnsafe()), 40404);
     final NodeRecord newRecord =
-        interpreter.createWithNewAddress(initialRecord, newSocketAddress, PRIV_KEY);
+        interpreter.createWithNewAddress(
+            initialRecord, newSocketAddress, Optional.of(5667), PRIV_KEY);
 
     assertThat(newRecord.getUdpAddress()).contains(newSocketAddress);
+    assertThat(newRecord.getTcpAddress())
+        .contains(new InetSocketAddress(newSocketAddress.getAddress(), 5667));
     assertThat(newRecord.get(EnrField.IP_V6)).isEqualTo(IPV6_LOCALHOST);
   }
 
@@ -224,9 +233,12 @@ class IdentitySchemaV4InterpreterTest {
             new EnrField(EnrField.IP_V6, IPV6_LOCALHOST), new EnrField(EnrField.UDP_V6, 3030));
     final InetSocketAddress newSocketAddress = new InetSocketAddress("127.0.0.1", 40404);
     final NodeRecord newRecord =
-        interpreter.createWithNewAddress(initialRecord, newSocketAddress, PRIV_KEY);
+        interpreter.createWithNewAddress(
+            initialRecord, newSocketAddress, Optional.of(5667), PRIV_KEY);
 
     assertThat(newRecord.getUdpAddress()).contains(newSocketAddress);
+    assertThat(newRecord.getTcpAddress())
+        .contains(new InetSocketAddress(newSocketAddress.getAddress(), 5667));
     assertThat(newRecord.get(EnrField.IP_V4)).isEqualTo(Bytes.wrap(new byte[] {127, 0, 0, 1}));
   }
 


### PR DESCRIPTION
## PR Description
Provide the old node record and new address to the `NewAddressHandler` instead of old and pre-updated node records. Update utility methods to add addresses to optionally support updating the TCP port as well as the address and UDP port.

This enables client code to delay adding the UDP or TCP address info to the ENR until the external IP address is known.

## Fixed Issue(s)
#116 