### PR TITLE
Include active sessions in the stream of live nodes

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManager.java
@@ -7,6 +7,7 @@ package org.ethereum.beacon.discovery;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 
@@ -46,4 +47,6 @@ public interface DiscoveryManager {
 
   /** Sends the TALKREQ so the specified {@code node} and returns the TALKRESP promise */
   CompletableFuture<Bytes> talk(NodeRecord nodeRecord, Bytes protocol, Bytes request);
+
+  Stream<NodeRecord> streamActiveSessions();
 }

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -205,5 +206,10 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
   @VisibleForTesting
   public Optional<NodeSession> getNodeSession(Bytes remoteNodeId) {
     return nodeSessionManager.getNodeSession(remoteNodeId);
+  }
+
+  @Override
+  public Stream<NodeRecord> streamActiveSessions() {
+    return nodeSessionManager.streamActiveSessions();
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystem.java
@@ -107,7 +107,8 @@ public class DiscoverySystem {
   }
 
   public Stream<NodeRecord> streamLiveNodes() {
-    return buckets.streamClosestNodes(Bytes32.ZERO);
+    return Stream.concat(
+        buckets.streamClosestNodes(Bytes32.ZERO), discoveryManager.streamActiveSessions());
   }
 
   public CompletableFuture<Collection<NodeRecord>> searchForNewPeers() {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -158,6 +159,12 @@ public class NodeSessionManager implements EnvelopeHandler {
   private Optional<InetSocketAddress> getRemoteSocketAddress(final Envelope envelope) {
     return Optional.ofNullable(envelope.get(Field.REMOTE_SENDER))
         .or(() -> envelope.get(Field.NODE).getUdpAddress());
+  }
+
+  public Stream<NodeRecord> streamActiveSessions() {
+    return recentSessions.values().stream()
+        .filter(NodeSession::isAuthenticated)
+        .flatMap(session -> session.getNodeRecord().stream());
   }
 
   private static class SessionKey {


### PR DESCRIPTION
## PR Description
Modifies the `DiscoverySystem.streamLiveNodes()` method to include nodes we have an `AUTHENTICATED` session with, as well as node records that are stored in the k-buckets.

This increases the set of nodes a client can consider connecting to without having to increase the bucket storage size or maintain a separate unbounded node table as before. Active sessions are already actively maintained and limited in size, but may contain a lot more nodes than are in the k-buckets because they aren't sorted by distance.