### PR TITLE
Optimization: Cache calculated NodeId in the NodeRecord

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -5,6 +5,8 @@
 package org.ethereum.beacon.discovery.schema;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -44,6 +46,7 @@ public class NodeRecord {
   // optional fields
   private final Map<String, Object> fields = new HashMap<>();
   private final IdentitySchemaInterpreter identitySchemaInterpreter;
+  private final Supplier<Bytes> nodeIdCache = Suppliers.memoize(this::calcNodeId);
 
   private NodeRecord(
       IdentitySchemaInterpreter identitySchemaInterpreter, UInt64 seq, Bytes signature) {
@@ -195,6 +198,10 @@ public class NodeRecord {
   }
 
   public Bytes getNodeId() {
+    return nodeIdCache.get();
+  }
+
+  private Bytes calcNodeId() {
     return identitySchemaInterpreter.getNodeId(this);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

`NodeId` calculation takes a lot of time and need to be cached 

![изображение](https://user-images.githubusercontent.com/8173857/146550210-2f62edc9-e387-4d05-91e1-3d70ef7d59ee.png)
