### PR TITLE
Move the caching of NodeId to be shared across NodeRecord instances

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -5,8 +5,6 @@
 package org.ethereum.beacon.discovery.schema;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -46,7 +44,6 @@ public class NodeRecord {
   // optional fields
   private final Map<String, Object> fields = new HashMap<>();
   private final IdentitySchemaInterpreter identitySchemaInterpreter;
-  private final Supplier<Bytes> nodeIdCache = Suppliers.memoize(this::calcNodeId);
 
   private NodeRecord(
       IdentitySchemaInterpreter identitySchemaInterpreter, UInt64 seq, Bytes signature) {
@@ -198,10 +195,6 @@ public class NodeRecord {
   }
 
   public Bytes getNodeId() {
-    return nodeIdCache.get();
-  }
-
-  private Bytes calcNodeId() {
     return identitySchemaInterpreter.getNodeId(this);
   }
 


### PR DESCRIPTION
## PR Description
The cache is now held in IdentitySchemaV4Interpreter, avoiding the need to create a new memoizing Supplier with every NodeRecord and avoiding the need to recalculate the NodeId if the same id is received from the network multiple times, which would result in multiple NodeRecord instances.
