### PR TITLE
Validate ENR field keys ordering and uniqueness

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -64,9 +64,7 @@ public class NodeRecord {
   }
 
   public static NodeRecord fromValues(
-      IdentitySchemaInterpreter identitySchemaInterpreter,
-      UInt64 seq,
-      List<EnrField> enrFields) {
+      IdentitySchemaInterpreter identitySchemaInterpreter, UInt64 seq, List<EnrField> enrFields) {
     return fromValues(identitySchemaInterpreter, seq, Optional.empty(), enrFields);
   }
 
@@ -93,17 +91,16 @@ public class NodeRecord {
       Optional<Bytes> maybeSignature,
       List<EnrField> enrFields) {
 
-    NodeRecord nodeRecord = maybeSignature
-        .map(signature -> new NodeRecord(identitySchemaInterpreter, seq, signature))
-        .orElseGet(() -> new NodeRecord(identitySchemaInterpreter, seq));
+    NodeRecord nodeRecord =
+        maybeSignature
+            .map(signature -> new NodeRecord(identitySchemaInterpreter, seq, signature))
+            .orElseGet(() -> new NodeRecord(identitySchemaInterpreter, seq));
     enrFields.forEach(enrField -> nodeRecord.set(enrField.getName(), enrField.getValue()));
     return nodeRecord;
   }
 
   private static void validateEnrFields(List<EnrField> enrFields) {
-    List<String> enrKeys = enrFields.stream()
-        .map(EnrField::getName)
-        .collect(Collectors.toList());
+    List<String> enrKeys = enrFields.stream().map(EnrField::getName).collect(Collectors.toList());
     if (!Comparators.isInStrictOrder(enrKeys, Comparator.naturalOrder())) {
       throw new IllegalArgumentException("ENR record keys are not in strict order");
     }
@@ -217,8 +214,7 @@ public class NodeRecord {
   private Bytes serializeImpl(boolean withSignature) {
     RlpType rlpRecord = withSignature ? asRlp() : asRlpNoSignature();
     byte[] bytes = RlpEncoder.encode(rlpRecord);
-    checkArgument(
-        bytes.length <= MAX_ENCODED_SIZE, "Node record exceeds maximum encoded size");
+    checkArgument(bytes.length <= MAX_ENCODED_SIZE, "Node record exceeds maximum encoded size");
     return Bytes.wrap(bytes);
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -4,10 +4,15 @@
 
 package org.ethereum.beacon.discovery.schema;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Comparators;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,24 +66,47 @@ public class NodeRecord {
   public static NodeRecord fromValues(
       IdentitySchemaInterpreter identitySchemaInterpreter,
       UInt64 seq,
-      List<EnrField> fieldKeyPairs) {
-    NodeRecord nodeRecord = new NodeRecord(identitySchemaInterpreter, seq);
-    fieldKeyPairs.forEach(objects -> nodeRecord.set(objects.getName(), objects.getValue()));
-    return nodeRecord;
+      List<EnrField> enrFields) {
+    return fromValues(identitySchemaInterpreter, seq, Optional.empty(), enrFields);
   }
 
-  @SuppressWarnings({"unchecked", "DefaultCharset"})
-  public static NodeRecord fromRawFields(
+  public static NodeRecord fromRawFieldsStrict(
       IdentitySchemaInterpreter identitySchemaInterpreter,
       UInt64 seq,
       Bytes signature,
       List<RlpType> rawFields) {
-    NodeRecord nodeRecord = new NodeRecord(identitySchemaInterpreter, seq, signature);
+
+    checkArgument(rawFields.size() % 2 == 0, "Non even rawFields list size");
+    List<EnrField> enrFields = new ArrayList<>(rawFields.size() / 2);
     for (int i = 0; i < rawFields.size(); i += 2) {
-      String key = new String(((RlpString) rawFields.get(i)).getBytes());
-      nodeRecord.set(key, enrFieldInterpreter.decode(key, rawFields.get(i + 1)));
+      String key = new String(((RlpString) rawFields.get(i)).getBytes(), StandardCharsets.UTF_8);
+      EnrField enrField = new EnrField(key, enrFieldInterpreter.decode(key, rawFields.get(i + 1)));
+      enrFields.add(enrField);
     }
+    validateEnrFields(enrFields);
+    return fromValues(identitySchemaInterpreter, seq, Optional.of(signature), enrFields);
+  }
+
+  private static NodeRecord fromValues(
+      IdentitySchemaInterpreter identitySchemaInterpreter,
+      UInt64 seq,
+      Optional<Bytes> maybeSignature,
+      List<EnrField> enrFields) {
+
+    NodeRecord nodeRecord = maybeSignature
+        .map(signature -> new NodeRecord(identitySchemaInterpreter, seq, signature))
+        .orElseGet(() -> new NodeRecord(identitySchemaInterpreter, seq));
+    enrFields.forEach(enrField -> nodeRecord.set(enrField.getName(), enrField.getValue()));
     return nodeRecord;
+  }
+
+  private static void validateEnrFields(List<EnrField> enrFields) {
+    List<String> enrKeys = enrFields.stream()
+        .map(EnrField::getName)
+        .collect(Collectors.toList());
+    if (!Comparators.isInStrictOrder(enrKeys, Comparator.naturalOrder())) {
+      throw new IllegalArgumentException("ENR record keys are not in strict order");
+    }
   }
 
   public String asBase64() {
@@ -189,7 +217,7 @@ public class NodeRecord {
   private Bytes serializeImpl(boolean withSignature) {
     RlpType rlpRecord = withSignature ? asRlp() : asRlpNoSignature();
     byte[] bytes = RlpEncoder.encode(rlpRecord);
-    Preconditions.checkArgument(
+    checkArgument(
         bytes.length <= MAX_ENCODED_SIZE, "Node record exceeds maximum encoded size");
     return Bytes.wrap(bytes);
   }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecordFactory.java
@@ -108,7 +108,7 @@ public class NodeRecordFactory {
               "No Ethereum record interpreter found for identity scheme %s", nodeIdentity));
     }
 
-    return NodeRecord.fromRawFields(
+    return NodeRecord.fromRawFieldsStrict(
         identitySchemaInterpreter,
         UInt64.fromBytes(RlpUtil.asString(rlpList.get(1), RlpUtil.CONS_UINT64)),
         RlpUtil.asString(rlpList.get(0), RlpUtil.CONS_ANY),

--- a/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
@@ -261,9 +261,8 @@ class IdentitySchemaV4InterpreterTest {
 
   @Test
   public void enrDeserializationWithWrongKeyOrderShouldFail() {
-    NodeRecord nodeRecord = createNodeRecord(
-        new EnrField(EnrField.TCP, 1234),
-        new EnrField(EnrField.UDP, 5678));
+    NodeRecord nodeRecord =
+        createNodeRecord(new EnrField(EnrField.TCP, 1234), new EnrField(EnrField.UDP, 5678));
     List<RlpType> rlpEntries = nodeRecord.asRlp().getValues();
     int tcpEntryIdx = rlpEntries.size() - 4;
     int udpEntryIdx = tcpEntryIdx + 2;

--- a/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
@@ -5,15 +5,20 @@
 package org.ethereum.beacon.discovery.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.Test;
+import org.web3j.rlp.RlpEncoder;
+import org.web3j.rlp.RlpList;
+import org.web3j.rlp.RlpType;
 
 class IdentitySchemaV4InterpreterTest {
 
@@ -240,6 +245,35 @@ class IdentitySchemaV4InterpreterTest {
     assertThat(newRecord.getTcpAddress())
         .contains(new InetSocketAddress(newSocketAddress.getAddress(), 5667));
     assertThat(newRecord.get(EnrField.IP_V4)).isEqualTo(Bytes.wrap(new byte[] {127, 0, 0, 1}));
+  }
+
+  @Test
+  public void enrDeserializationWithDuplicateFieldKeyShouldFail() {
+    NodeRecord nodeRecord = createNodeRecord(new EnrField(EnrField.TCP, 1234));
+    List<RlpType> rlpEntries = nodeRecord.asRlp().getValues();
+    rlpEntries.add(rlpEntries.get(rlpEntries.size() - 2));
+    rlpEntries.add(rlpEntries.get(rlpEntries.size() - 1));
+    RlpList rlpList = new RlpList(rlpEntries);
+    byte[] duplicateEntryBytes = RlpEncoder.encode(rlpList);
+    assertThatThrownBy(() -> NodeRecordFactory.DEFAULT.fromBytes(duplicateEntryBytes))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void enrDeserializationWithWrongKeyOrderShouldFail() {
+    NodeRecord nodeRecord = createNodeRecord(
+        new EnrField(EnrField.TCP, 1234),
+        new EnrField(EnrField.UDP, 5678));
+    List<RlpType> rlpEntries = nodeRecord.asRlp().getValues();
+    int tcpEntryIdx = rlpEntries.size() - 4;
+    int udpEntryIdx = tcpEntryIdx + 2;
+    ArrayList<RlpType> wrongOrderList = new ArrayList<>(rlpEntries.subList(0, tcpEntryIdx));
+    wrongOrderList.addAll(rlpEntries.subList(udpEntryIdx, udpEntryIdx + 2));
+    wrongOrderList.addAll(rlpEntries.subList(tcpEntryIdx, tcpEntryIdx + 2));
+    RlpList rlpList = new RlpList(wrongOrderList);
+    byte[] invalidEnrBytes = RlpEncoder.encode(rlpList);
+    assertThatThrownBy(() -> NodeRecordFactory.DEFAULT.fromBytes(invalidEnrBytes))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   private Optional<InetSocketAddress> getTcpAddressForNodeRecordWithFields(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

Special thanks to @asanso for finding and reporting this issue 👍 

Discovery doesn't validate field key ordering and uniqueness of wire ENRs. Thus any number of ENRs with valid signature could be generated and feed to the discovery. Any severe security impact was not found. 

As per [spec](https://github.com/ethereum/devp2p/blob/master/enr.md#record-structure): 
>The key/value pairs must be sorted by key and must be unique, i.e. any key may be present only once.
