### PR TITLE
Make `ExternalAddressSelector` pluggable

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -16,6 +16,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.message.FindNodeMessage;
 import org.ethereum.beacon.discovery.message.PingMessage;
 import org.ethereum.beacon.discovery.message.TalkReqMessage;
+import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
 import org.ethereum.beacon.discovery.network.DiscoveryClient;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryClientImpl;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryServer;
@@ -73,7 +74,8 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
       NodeRecordFactory nodeRecordFactory,
       Scheduler taskScheduler,
       ExpirationSchedulerFactory expirationSchedulerFactory,
-      TalkHandler talkHandler) {
+      TalkHandler talkHandler,
+      ExternalAddressSelector externalAddressSelector) {
     this.localNodeRecordStore = localNodeRecordStore;
     final NodeRecord homeNodeRecord = localNodeRecordStore.getLocalNodeRecord();
 
@@ -97,7 +99,12 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
                 outgoingPipeline, taskScheduler, nodeRecordFactory, nodeSessionManager))
         .addHandler(new MessagePacketHandler(nodeRecordFactory))
         .addHandler(new UnauthorizedMessagePacketHandler())
-        .addHandler(new MessageHandler(localNodeRecordStore, talkHandler, this::requestUpdatedEnr))
+        .addHandler(
+            new MessageHandler(
+                localNodeRecordStore,
+                talkHandler,
+                this::requestUpdatedEnr,
+                externalAddressSelector))
         .addHandler(new BadPacketHandler());
     final FluxSink<NetworkParcel> outgoingSink = outgoingMessages.sink();
     outgoingPipeline

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/DefaultExternalAddressSelector.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/DefaultExternalAddressSelector.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message.handler;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
+
+public class DefaultExternalAddressSelector implements ExternalAddressSelector {
+
+  static final int MIN_CONFIRMATIONS = 2;
+  static final int MAX_EXTERNAL_ADDRESS_COUNT = 50;
+  static final Duration TTL = Duration.ofMinutes(5);
+
+  /**
+   * Tracks an estimate of the number of nodes that have reported a particular external address. The
+   * number of addresses we keep counts for is limited to avoid peers filling our memory by
+   * reporting a large number of different address.
+   *
+   * <p>The count must never be greater than the number of unique nodes that have reported that
+   * address.
+   *
+   * <p>Also tracks the last time an address is reported so that stale addresses can be removed even
+   * if they have accumlated a lot of reports.
+   */
+  private final Map<InetSocketAddress, ReportData> reportedAddresses = new HashMap<>();
+
+  private final LocalNodeRecordStore localNodeRecordStore;
+
+  public DefaultExternalAddressSelector(final LocalNodeRecordStore localNodeRecordStore) {
+    this.localNodeRecordStore = localNodeRecordStore;
+  }
+
+  @Override
+  public void onExternalAddressReport(
+      final Optional<InetSocketAddress> previouslyReportedAddress,
+      final InetSocketAddress reportedAddress,
+      final Instant reportedTime) {
+
+    previouslyReportedAddress.ifPresent(this::removeVote);
+    addVote(reportedAddress, reportedTime);
+
+    removeStaleAddresses(reportedTime);
+    limitTrackedAddresses();
+
+    selectExternalAddress()
+        .ifPresent(
+            selectedAddress -> {
+              final Optional<InetSocketAddress> currentAddress =
+                  localNodeRecordStore.getLocalNodeRecord().getUdpAddress();
+              if (currentAddress.map(current -> !current.equals(selectedAddress)).orElse(true)) {
+                localNodeRecordStore.onSocketAddressChanged(selectedAddress);
+              }
+            });
+  }
+
+  private void removeStaleAddresses(final Instant now) {
+    final Instant cutOffTime = now.minus(TTL);
+    final List<InetSocketAddress> staleAddresses =
+        reportedAddresses.entrySet().stream()
+            .filter(entry -> entry.getValue().lastReportedBefore(cutOffTime))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+    staleAddresses.forEach(reportedAddresses::remove);
+  }
+
+  private void limitTrackedAddresses() {
+    while (reportedAddresses.size() > MAX_EXTERNAL_ADDRESS_COUNT) {
+      // Too many addresses being tracked, remove the one with the fewest votes
+      reportedAddresses.entrySet().stream()
+          .min(Map.Entry.comparingByValue(Comparator.comparing(ReportData::getLastReportedTime)))
+          .map(Map.Entry::getKey)
+          .ifPresent(reportedAddresses::remove);
+    }
+  }
+
+  private void addVote(final InetSocketAddress reportedAddress, final Instant reportTime) {
+    reportedAddresses.compute(
+        reportedAddress,
+        (key, currentValue) ->
+            currentValue != null ? currentValue.addReport(reportTime) : new ReportData(reportTime));
+  }
+
+  private void removeVote(final InetSocketAddress previousAddress) {
+    reportedAddresses.compute(
+        previousAddress,
+        (key, currentValue) -> currentValue != null ? currentValue.removeReport() : null);
+  }
+
+  private Optional<InetSocketAddress> selectExternalAddress() {
+    return reportedAddresses.entrySet().stream()
+        .filter(entry -> entry.getValue().getReportCount() >= MIN_CONFIRMATIONS)
+        .max(Map.Entry.comparingByValue(Comparator.comparing(ReportData::getReportCount)))
+        .map(Map.Entry::getKey);
+  }
+
+  @VisibleForTesting
+  void assertInvariants() {
+    checkState(
+        reportedAddresses.size() <= MAX_EXTERNAL_ADDRESS_COUNT,
+        "Should limit number of tracked addresses. Size %s",
+        reportedAddresses.size());
+    checkState(
+        reportedAddresses.values().stream().noneMatch(data -> data.getReportCount() <= 0),
+        "Should not have counts less than 1 (%s)",
+        reportedAddresses);
+  }
+
+  private static class ReportData {
+    private int reportCount;
+    private Instant lastReportedTime;
+
+    public ReportData(final Instant time) {
+      this.reportCount = 1;
+      this.lastReportedTime = time;
+    }
+
+    public ReportData addReport(final Instant time) {
+      lastReportedTime = time;
+      reportCount++;
+      return this;
+    }
+
+    public ReportData removeReport() {
+      reportCount--;
+      return reportCount > 0 ? this : null;
+    }
+
+    public Instant getLastReportedTime() {
+      return lastReportedTime;
+    }
+
+    public int getReportCount() {
+      return reportCount;
+    }
+
+    public boolean lastReportedBefore(final Instant cutOffTime) {
+      return lastReportedTime.isBefore(cutOffTime);
+    }
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
@@ -4,149 +4,16 @@
 
 package org.ethereum.beacon.discovery.message.handler;
 
-import static com.google.common.base.Preconditions.checkState;
-
-import com.google.common.annotations.VisibleForTesting;
 import java.net.InetSocketAddress;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 
-public class ExternalAddressSelector {
+public interface ExternalAddressSelector {
 
-  static final int MIN_CONFIRMATIONS = 2;
-  static final int MAX_EXTERNAL_ADDRESS_COUNT = 50;
-  static final Duration TTL = Duration.ofMinutes(5);
+  ExternalAddressSelector NOOP = (_1, _2, _3) -> {};
 
-  /**
-   * Tracks an estimate of the number of nodes that have reported a particular external address. The
-   * number of addresses we keep counts for is limited to avoid peers filling our memory by
-   * reporting a large number of different address.
-   *
-   * <p>The count must never be greater than the number of unique nodes that have reported that
-   * address.
-   *
-   * <p>Also tracks the last time an address is reported so that stale addresses can be removed even
-   * if they have accumlated a lot of reports.
-   */
-  private final Map<InetSocketAddress, ReportData> reportedAddresses = new HashMap<>();
-
-  private final LocalNodeRecordStore localNodeRecordStore;
-
-  public ExternalAddressSelector(final LocalNodeRecordStore localNodeRecordStore) {
-    this.localNodeRecordStore = localNodeRecordStore;
-  }
-
-  public void onExternalAddressReport(
+  void onExternalAddressReport(
       final Optional<InetSocketAddress> previouslyReportedAddress,
       final InetSocketAddress reportedAddress,
-      final Instant reportedTime) {
-
-    previouslyReportedAddress.ifPresent(this::removeVote);
-    addVote(reportedAddress, reportedTime);
-
-    removeStaleAddresses(reportedTime);
-    limitTrackedAddresses();
-
-    selectExternalAddress()
-        .ifPresent(
-            selectedAddress -> {
-              final Optional<InetSocketAddress> currentAddress =
-                  localNodeRecordStore.getLocalNodeRecord().getUdpAddress();
-              if (currentAddress.map(current -> !current.equals(selectedAddress)).orElse(true)) {
-                localNodeRecordStore.onSocketAddressChanged(selectedAddress);
-              }
-            });
-  }
-
-  private void removeStaleAddresses(final Instant now) {
-    final Instant cutOffTime = now.minus(TTL);
-    final List<InetSocketAddress> staleAddresses =
-        reportedAddresses.entrySet().stream()
-            .filter(entry -> entry.getValue().lastReportedBefore(cutOffTime))
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-    staleAddresses.forEach(reportedAddresses::remove);
-  }
-
-  private void limitTrackedAddresses() {
-    while (reportedAddresses.size() > MAX_EXTERNAL_ADDRESS_COUNT) {
-      // Too many addresses being tracked, remove the one with the fewest votes
-      reportedAddresses.entrySet().stream()
-          .min(Map.Entry.comparingByValue(Comparator.comparing(ReportData::getLastReportedTime)))
-          .map(Map.Entry::getKey)
-          .ifPresent(reportedAddresses::remove);
-    }
-  }
-
-  private void addVote(final InetSocketAddress reportedAddress, final Instant reportTime) {
-    reportedAddresses.compute(
-        reportedAddress,
-        (key, currentValue) ->
-            currentValue != null ? currentValue.addReport(reportTime) : new ReportData(reportTime));
-  }
-
-  private void removeVote(final InetSocketAddress previousAddress) {
-    reportedAddresses.compute(
-        previousAddress,
-        (key, currentValue) -> currentValue != null ? currentValue.removeReport() : null);
-  }
-
-  private Optional<InetSocketAddress> selectExternalAddress() {
-    return reportedAddresses.entrySet().stream()
-        .filter(entry -> entry.getValue().getReportCount() >= MIN_CONFIRMATIONS)
-        .max(Map.Entry.comparingByValue(Comparator.comparing(ReportData::getReportCount)))
-        .map(Map.Entry::getKey);
-  }
-
-  @VisibleForTesting
-  void assertInvariants() {
-    checkState(
-        reportedAddresses.size() <= MAX_EXTERNAL_ADDRESS_COUNT,
-        "Should limit number of tracked addresses. Size %s",
-        reportedAddresses.size());
-    checkState(
-        reportedAddresses.values().stream().noneMatch(data -> data.getReportCount() <= 0),
-        "Should not have counts less than 1 (%s)",
-        reportedAddresses);
-  }
-
-  private static class ReportData {
-    private int reportCount;
-    private Instant lastReportedTime;
-
-    public ReportData(final Instant time) {
-      this.reportCount = 1;
-      this.lastReportedTime = time;
-    }
-
-    public ReportData addReport(final Instant time) {
-      lastReportedTime = time;
-      reportCount++;
-      return this;
-    }
-
-    public ReportData removeReport() {
-      reportCount--;
-      return reportCount > 0 ? this : null;
-    }
-
-    public Instant getLastReportedTime() {
-      return lastReportedTime;
-    }
-
-    public int getReportCount() {
-      return reportCount;
-    }
-
-    public boolean lastReportedBefore(final Instant cutOffTime) {
-      return lastReportedTime.isBefore(cutOffTime);
-    }
-  }
+      final Instant reportedTime);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.TalkHandler;
 import org.ethereum.beacon.discovery.message.V5Message;
 import org.ethereum.beacon.discovery.message.handler.EnrUpdateTracker.EnrUpdater;
+import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
@@ -23,10 +24,15 @@ public class MessageHandler implements EnvelopeHandler {
   private final MessageProcessor messageProcessor;
 
   public MessageHandler(
-      LocalNodeRecordStore localNodeRecordStore, TalkHandler talkHandler, EnrUpdater enrUpdater) {
+      LocalNodeRecordStore localNodeRecordStore,
+      TalkHandler talkHandler,
+      EnrUpdater enrUpdater,
+      ExternalAddressSelector externalAddressSelector) {
+
     this.messageProcessor =
         new MessageProcessor(
-            new DiscoveryV5MessageProcessor(localNodeRecordStore, talkHandler, enrUpdater));
+            new DiscoveryV5MessageProcessor(
+                localNodeRecordStore, talkHandler, enrUpdater, externalAddressSelector));
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
@@ -37,12 +37,15 @@ public class DiscoveryV5MessageProcessor implements DiscoveryMessageProcessor<V5
   private final Map<MessageCode, MessageHandler> messageHandlers = new HashMap<>();
 
   public DiscoveryV5MessageProcessor(
-      LocalNodeRecordStore localNodeRecordStore, TalkHandler talkHandler, EnrUpdater enrUpdater) {
+      LocalNodeRecordStore localNodeRecordStore,
+      TalkHandler talkHandler,
+      EnrUpdater enrUpdater,
+      ExternalAddressSelector externalAddressSelector) {
+
     final EnrUpdateTracker enrUpdateTracker = new EnrUpdateTracker(enrUpdater);
     messageHandlers.put(MessageCode.PING, new PingHandler(enrUpdateTracker));
     messageHandlers.put(
-        MessageCode.PONG,
-        new PongHandler(new ExternalAddressSelector(localNodeRecordStore), enrUpdateTracker));
+        MessageCode.PONG, new PongHandler(externalAddressSelector, enrUpdateTracker));
     messageHandlers.put(MessageCode.FINDNODE, new FindNodeHandler());
     messageHandlers.put(MessageCode.NODES, new NodesHandler());
     messageHandlers.put(MessageCode.TALKREQ, new TalkReqHandler(talkHandler));

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.liveness.LivenessChecker;
+import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
 import org.ethereum.beacon.discovery.network.NettyDiscoveryServerImpl;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
@@ -73,7 +74,8 @@ public class DiscoveryNetworkTest {
             NODE_RECORD_FACTORY_NO_VERIFICATION,
             Schedulers.createDefault().newSingleThreadDaemon("tasks-1"),
             expirationSchedulerFactory,
-            TalkHandler.NOOP);
+            TalkHandler.NOOP,
+            ExternalAddressSelector.NOOP);
     livenessChecker1.setPinger(discoveryManager1::ping);
     DiscoveryManagerImpl discoveryManager2 =
         new DiscoveryManagerImpl(
@@ -89,7 +91,8 @@ public class DiscoveryNetworkTest {
             NODE_RECORD_FACTORY_NO_VERIFICATION,
             Schedulers.createDefault().newSingleThreadDaemon("tasks-2"),
             expirationSchedulerFactory,
-            TalkHandler.NOOP);
+            TalkHandler.NOOP,
+            ExternalAddressSelector.NOOP);
     livenessChecker2.setPinger(discoveryManager2::ping);
 
     // 3) Expect standard 1 => 2 dialog

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -33,6 +33,7 @@ import org.ethereum.beacon.discovery.liveness.LivenessChecker;
 import org.ethereum.beacon.discovery.message.FindNodeMessage;
 import org.ethereum.beacon.discovery.message.PingMessage;
 import org.ethereum.beacon.discovery.message.handler.EnrUpdateTracker;
+import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
 import org.ethereum.beacon.discovery.network.NetworkParcel;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
 import org.ethereum.beacon.discovery.packet.Header;
@@ -222,7 +223,10 @@ public class HandshakeHandlersTest {
 
     MessageHandler messageHandler =
         new MessageHandler(
-            localNodeRecordStoreAt1, TalkHandler.NOOP, EnrUpdateTracker.EnrUpdater.NOOP);
+            localNodeRecordStoreAt1,
+            TalkHandler.NOOP,
+            EnrUpdateTracker.EnrUpdater.NOOP,
+            ExternalAddressSelector.NOOP);
     messageHandler.handle(envelopeAt1From2WithMessage);
 
     // Node 2 handles message from Node 1

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/DefaultExternalAddressSelectorTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/DefaultExternalAddressSelectorTest.java
@@ -6,7 +6,8 @@ package org.ethereum.beacon.discovery.message.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter.ADDRESS_UPDATER;
-import static org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector.MIN_CONFIRMATIONS;
+import static org.ethereum.beacon.discovery.message.handler.DefaultExternalAddressSelector.MAX_EXTERNAL_ADDRESS_COUNT;
+import static org.ethereum.beacon.discovery.message.handler.DefaultExternalAddressSelector.MIN_CONFIRMATIONS;
 
 import java.net.InetSocketAddress;
 import java.time.Instant;
@@ -19,7 +20,7 @@ import org.ethereum.beacon.discovery.storage.NodeRecordListener;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-class ExternalAddressSelectorTest {
+class DefaultExternalAddressSelectorTest {
 
   private static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 2000);
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 2002);
@@ -33,8 +34,8 @@ class ExternalAddressSelectorTest {
       new LocalNodeRecordStore(
           originalNodeRecord, nodeId, NodeRecordListener.NOOP, ADDRESS_UPDATER);
 
-  private final ExternalAddressSelector selector =
-      new ExternalAddressSelector(localNodeRecordStore);
+  private final DefaultExternalAddressSelector selector =
+      new DefaultExternalAddressSelector(localNodeRecordStore);
 
   @AfterEach
   void tearDown() {
@@ -102,7 +103,7 @@ class ExternalAddressSelectorTest {
     }
 
     // Report a lot of different address to overflow the cache
-    for (int i = 0; i < ExternalAddressSelector.MAX_EXTERNAL_ADDRESS_COUNT; i++) {
+    for (int i = 0; i < MAX_EXTERNAL_ADDRESS_COUNT; i++) {
       selector.onExternalAddressReport(
           Optional.empty(), new InetSocketAddress(3000 + i), START_TIME);
     }
@@ -131,7 +132,7 @@ class ExternalAddressSelectorTest {
     selector.onExternalAddressReport(
         Optional.empty(),
         new InetSocketAddress("127.0.0.6", 2004),
-        START_TIME.plus(ExternalAddressSelector.TTL).plusMillis(1));
+        START_TIME.plus(DefaultExternalAddressSelector.TTL).plusMillis(1));
     assertSelectedAddress(ADDRESS3);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

Currently there is no mean to set a fixed external advertised address if doesn't match the address seen by other discv5 nodes: the local node record is overridden due to `Ping` responses. 

This PR makes `ExternalAddressSelector` pluggable so the client code could replace the default selector with `NOOP` or any other custom implementation 
