### PR TITLE
Switch to parsing RLP with tuweni-rlp instead of web3j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,9 @@ repositories {
 
 dependencies {
   implementation 'org.apache.tuweni:tuweni-bytes'
-  implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.apache.tuweni:tuweni-crypto'
+  implementation 'org.apache.tuweni:tuweni-rlp'
+  implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.bouncycastle:bcprov-jdk15on'
 
   implementation 'com.google.guava:guava'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -19,12 +19,13 @@ dependencyManagement {
     dependency 'org.bouncycastle:bcprov-jdk15on:1.70'
 
     dependency 'org.assertj:assertj-core:3.22.0'
-    dependency 'org.web3j:core:5.0.0'
+    dependency 'org.web3j:core:4.9.0'
     dependency 'org.mockito:mockito-core:4.3.1'
 
     dependencySet(group: 'org.apache.tuweni', version: '2.1.0') {
       entry 'tuweni-bytes'
       entry 'tuweni-crypto'
+      entry 'tuweni-rlp'
       entry 'tuweni-units'
     }
 

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -47,7 +47,7 @@ public class DiscoverySystemBuilder {
   private Optional<InetSocketAddress> listenAddress = Optional.empty();
   private NodeRecord localNodeRecord;
   private Bytes privateKey;
-  private final NodeRecordFactory nodeRecordFactory = NodeRecordFactory.DEFAULT;
+  private NodeRecordFactory nodeRecordFactory = NodeRecordFactory.DEFAULT;
   private Schedulers schedulers;
   private NodeRecordListener localNodeRecordListener = NodeRecordListener.NOOP;
   private NewAddressHandler newAddressHandler;
@@ -76,6 +76,11 @@ public class DiscoverySystemBuilder {
 
   public DiscoverySystemBuilder privateKey(final Bytes privateKey) {
     this.privateKey = privateKey;
+    return this;
+  }
+
+  public DiscoverySystemBuilder nodeRecordFactory(NodeRecordFactory nodeRecordFactory) {
+    this.nodeRecordFactory = nodeRecordFactory;
     return this;
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/message/TalkRespMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/TalkRespMessage.java
@@ -4,16 +4,12 @@
 
 package org.ethereum.beacon.discovery.message;
 
-import static org.ethereum.beacon.discovery.util.RlpUtil.CONS_ANY;
-import static org.ethereum.beacon.discovery.util.RlpUtil.maxSize;
+import static org.ethereum.beacon.discovery.util.RlpUtil.checkMaxSize;
 
-import java.util.List;
 import java.util.Objects;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
 import org.ethereum.beacon.discovery.util.RlpUtil;
-import org.web3j.rlp.RlpEncoder;
-import org.web3j.rlp.RlpList;
-import org.web3j.rlp.RlpString;
 
 /** TALKRESP is the response to TALKREQ. */
 public class TalkRespMessage implements V5Message {
@@ -29,8 +25,13 @@ public class TalkRespMessage implements V5Message {
   }
 
   public static TalkRespMessage fromBytes(Bytes bytes) {
-    List<Bytes> list = RlpUtil.decodeListOfStrings(bytes, maxSize(8), CONS_ANY);
-    return new TalkRespMessage(list.get(0), list.get(1));
+    return RlpUtil.readRlpList(
+        bytes,
+        reader -> {
+          final Bytes requestId = checkMaxSize(reader.readValue(), MAX_REQUEST_ID_SIZE);
+          final Bytes response = reader.readValue();
+          return new TalkRespMessage(requestId, response);
+        });
   }
 
   @Override
@@ -46,10 +47,11 @@ public class TalkRespMessage implements V5Message {
   public Bytes getBytes() {
     return Bytes.concatenate(
         Bytes.of(getCode().byteCode()),
-        Bytes.wrap(
-            RlpEncoder.encode(
-                new RlpList(
-                    RlpString.create(requestId.toArray()), RlpString.create(response.toArray())))));
+        RLP.encodeList(
+            writer -> {
+              writer.writeValue(requestId);
+              writer.writeValue(response);
+            }));
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
@@ -30,4 +30,9 @@ public class IncomingMessageSink extends SimpleChannelInboundHandler<Envelope> {
     logger.trace(() -> String.format("Incoming packet %s in session %s", msg, ctx));
     messageSink.next(msg);
   }
+
+  @Override
+  public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
+    logger.error("Unexpected exception caught", cause);
+  }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery.pipeline;
 
 import static org.ethereum.beacon.discovery.pipeline.Field.INCOMING;
+import static org.ethereum.beacon.discovery.util.Utils.RECOVERABLE_ERRORS_PREDICATE;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +32,9 @@ public class PipelineImpl implements Pipeline {
       pipeline = pipeline.doOnNext(handler::handle);
     }
     Flux.from(pipeline)
-        .onErrorContinue((err, msg) -> LOG.debug("Error while processing message: " + err))
+        .onErrorContinue(
+            RECOVERABLE_ERRORS_PREDICATE,
+            (err, msg) -> LOG.debug("Error while processing message: " + err))
         .subscribe();
     return this;
   }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -72,6 +72,14 @@ public class MessagePacketHandler implements EnvelopeHandler {
       logger.debug(error, ex);
       envelope.remove(Field.PACKET_MESSAGE);
       envelope.put(Field.BAD_PACKET, packet);
+    } catch (Throwable t) {
+      logger.warn(
+          "Unexpected error while reading message [{}] from node {}",
+          packet,
+          session.getNodeRecord(),
+          t);
+      envelope.remove(Field.PACKET_MESSAGE);
+      envelope.put(Field.BAD_PACKET, packet);
     }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreter.java
@@ -4,11 +4,11 @@
 
 package org.ethereum.beacon.discovery.schema;
 
-import org.web3j.rlp.RlpType;
+import org.apache.tuweni.rlp.RLPWriter;
 
 /** Encoder/decoder for fields of ethereum node record */
 public interface EnrFieldInterpreter {
-  Object decode(String key, RlpType rlpType);
+  Object decode(String key, Object rlpType);
 
-  RlpType encode(String key, Object object);
+  void encode(RLPWriter writer, String key, Object object);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/EnrFieldInterpreterV4.java
@@ -4,55 +4,81 @@
 
 package org.ethereum.beacon.discovery.schema;
 
+import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLPWriter;
+import org.ethereum.beacon.discovery.util.RlpDecodeException;
 import org.ethereum.beacon.discovery.util.RlpUtil;
-import org.web3j.rlp.RlpList;
-import org.web3j.rlp.RlpString;
-import org.web3j.rlp.RlpType;
 
 public class EnrFieldInterpreterV4 implements EnrFieldInterpreter {
 
-  public static final Function<RlpString, Object> DEFAULT_DECODER =
-      rlp -> Bytes.wrap(rlp.getBytes());
+  public static final Function<Object, Object> DEFAULT_DECODER = Function.identity();
   public static final EnrFieldInterpreterV4 DEFAULT = new EnrFieldInterpreterV4();
 
-  private final Map<String, Function<RlpString, Object>> fieldDecoders = new HashMap<>();
+  private final Map<String, Function<Object, Object>> fieldDecoders = new HashMap<>();
 
   @SuppressWarnings({"DefaultCharset"})
   public EnrFieldInterpreterV4() {
-    fieldDecoders.put(EnrField.PKEY_SECP256K1, rlpString -> Bytes.wrap(rlpString.getBytes()));
+    fieldDecoders.put(EnrField.PKEY_SECP256K1, Function.identity());
     fieldDecoders.put(
-        EnrField.ID, rlpString -> IdentitySchema.fromString(new String(rlpString.getBytes())));
-    fieldDecoders.put(EnrField.IP_V4, rlpString -> Bytes.wrap(rlpString.getBytes()));
-    fieldDecoders.put(EnrField.TCP, rlpString -> rlpString.asPositiveBigInteger().intValue());
-    fieldDecoders.put(EnrField.UDP, rlpString -> rlpString.asPositiveBigInteger().intValue());
-    fieldDecoders.put(EnrField.IP_V6, rlpString -> Bytes.wrap(rlpString.getBytes()));
-    fieldDecoders.put(EnrField.TCP_V6, rlpString -> rlpString.asPositiveBigInteger().intValue());
-    fieldDecoders.put(EnrField.UDP_V6, rlpString -> rlpString.asPositiveBigInteger().intValue());
+        EnrField.ID,
+        fromBytes(bytes -> IdentitySchema.fromString(new String(bytes.toArrayUnsafe()))));
+    fieldDecoders.put(EnrField.IP_V4, Function.identity());
+    fieldDecoders.put(EnrField.TCP, fromBytes(bytes -> bytes.toUnsignedBigInteger().intValue()));
+    fieldDecoders.put(EnrField.UDP, fromBytes(bytes -> bytes.toUnsignedBigInteger().intValue()));
+    fieldDecoders.put(EnrField.IP_V6, Function.identity());
+    fieldDecoders.put(EnrField.TCP_V6, fromBytes(bytes -> bytes.toUnsignedBigInteger().intValue()));
+    fieldDecoders.put(EnrField.UDP_V6, fromBytes(bytes -> bytes.toUnsignedBigInteger().intValue()));
+  }
+
+  private static Function<Object, Object> fromBytes(final Function<Bytes, Object> decoder) {
+    return value -> {
+      if (!(value instanceof Bytes)) {
+        throw new RlpDecodeException("Expected Bytes but got " + value.getClass());
+      }
+      return decoder.apply((Bytes) value);
+    };
   }
 
   @Override
-  public Object decode(String key, RlpType rlpType) {
-    if (rlpType instanceof RlpList) {
-      return ((RlpList) rlpType)
-          .getValues().stream().map(v -> decode(key, v)).collect(Collectors.toList());
+  public Object decode(String key, Object data) {
+    Function<Object, Object> fieldDecoder = fieldDecoders.getOrDefault(key, DEFAULT_DECODER);
+    return fieldDecoder.apply(data);
+  }
+
+  @Override
+  public void encode(final RLPWriter writer, final String key, final Object object) {
+    encode(writer, object, RlpUtil.MAX_NESTED_LIST_LEVELS);
+  }
+
+  private void encode(
+      final RLPWriter writer, final Object object, final int remainingNestingLevels) {
+    if (object instanceof Bytes) {
+      writer.writeValue((Bytes) object);
+    } else if (object instanceof BigInteger) {
+      writer.writeBigInteger((BigInteger) object);
+    } else if (object instanceof Long) {
+      writer.writeLong((long) object);
+    } else if (object instanceof Integer) {
+      writer.writeInt((int) object);
+    } else if (object == null) {
+      writer.writeByteArray(new byte[0]);
+    } else if (object instanceof IdentitySchema) {
+      writer.writeString(((IdentitySchema) object).stringName());
+    } else if (object instanceof List) {
+      if (remainingNestingLevels < 0) {
+        throw new RuntimeException("Cannot encode value - max nested list level exceeded");
+      }
+      writer.writeList(
+          (List<?>) object,
+          (listWriter, value) -> encode(listWriter, value, remainingNestingLevels - 1));
+    } else {
+      throw new RuntimeException(
+          "Couldn't encode value of type " + object.getClass() + ": no serializer found.");
     }
-
-    Function<RlpString, Object> fieldDecoder = fieldDecoders.getOrDefault(key, DEFAULT_DECODER);
-    return fieldDecoder.apply((RlpString) rlpType);
-  }
-
-  @Override
-  public RlpType encode(String key, Object object) {
-    return RlpUtil.encode(
-        object,
-        o ->
-            String.format(
-                "Couldn't encode field %s with value %s of type %s: no serializer found.",
-                key, object, object.getClass()));
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/util/RlpUtil.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/RlpUtil.java
@@ -4,256 +4,45 @@
 
 package org.ethereum.beacon.discovery.util;
 
-import static org.web3j.rlp.RlpDecoder.OFFSET_LONG_LIST;
-import static org.web3j.rlp.RlpDecoder.OFFSET_SHORT_LIST;
-
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt64;
-import org.ethereum.beacon.discovery.schema.IdentitySchema;
-import org.web3j.rlp.RlpDecoder;
-import org.web3j.rlp.RlpList;
-import org.web3j.rlp.RlpString;
-import org.web3j.rlp.RlpType;
+import org.apache.tuweni.rlp.RLP;
+import org.apache.tuweni.rlp.RLPReader;
 
-/**
- * Handy utilities used for RLP encoding and decoding and not fulfilled by {@link
- * org.web3j.rlp.RlpEncoder} and {@link RlpDecoder}
- */
+/** Handy utilities used for RLP encoding and decoding. */
 public class RlpUtil {
-  public interface BytesConstraint extends Predicate<Bytes> {}
+  public static final int UINT64_MAX_SIZE = 8;
+  public static final int MAX_NESTED_LIST_LEVELS = 3;
 
-  public static final BytesConstraint CONS_ANY = b -> true;
-  public static final BytesConstraint CONS_UINT64 = maxSize(8);
-
-  public static BytesConstraint strictSize(int size) {
-    return b -> b.size() == size;
+  public static Bytes checkMaxSize(final Bytes value, final int maxSize) {
+    if (value.size() > maxSize) {
+      throw new RlpDecodeException(
+          "Value of size " + value.size() + " exceeds max size " + maxSize);
+    }
+    return value;
   }
 
-  public static BytesConstraint maxSize(int maxSize) {
-    return b -> b.size() <= maxSize;
+  public static Bytes checkSizeEither(final Bytes value, final int size1, final int size2) {
+    if (value.size() != size1 && value.size() != size2) {
+      throw new RlpDecodeException(
+          "Value of size " + value.size() + " not one of " + size1 + " or " + size2);
+    }
+    return value;
   }
 
-  public static BytesConstraint minMaxSize(int minSize, int maxSize) {
-    return b -> b.size() <= maxSize && b.size() >= minSize;
-  }
-
-  public static BytesConstraint enumSizes(int... sizes) {
-    return b -> Arrays.stream(sizes).anyMatch(s -> s == b.size());
-  }
-
-  /**
-   * Calculates length of list beginning from the start of the data. So, there could everything else
-   * after first list in data, method helps to cut data in this case.
-   */
-  private static int calcListLen(Bytes data) {
-    int prefix = data.get(0) & 0xFF;
-    int prefixAddon = 1;
-    if (prefix >= OFFSET_SHORT_LIST && prefix <= OFFSET_LONG_LIST) {
-
-      // 4. the data is a list if the range of the
-      // first byte is [0xc0, 0xf7], and the concatenation of
-      // the RLP encodings of all items of the list which the
-      // total payload is equal to the first byte minus 0xc0 follows the first byte;
-
-      byte listLen = (byte) (prefix - OFFSET_SHORT_LIST);
-      return listLen & 0xFF + prefixAddon;
-    } else if (prefix > OFFSET_LONG_LIST) {
-
-      // 5. the data is a list if the range of the
-      // first byte is [0xf8, 0xff], and the total payload of the
-      // list which length is equal to the
-      // first byte minus 0xf7 follows the first byte,
-      // and the concatenation of the RLP encodings of all items of
-      // the list follows the total payload of the list;
-
-      int lenOfListLen = (prefix - OFFSET_LONG_LIST) & 0xFF;
-      prefixAddon += lenOfListLen;
-      return UInt64.fromBytes(Utils.leftPad(data.slice(1, lenOfListLen & 0xFF), 8)).intValue()
-          + prefixAddon;
-    } else {
-      throw new RuntimeException("Not a start of RLP list!!");
+  public static void checkComplete(final RLPReader reader) {
+    if (!reader.isComplete()) {
+      throw new RlpDecodeException("Unexpected trailing data detected");
     }
   }
 
-  /**
-   * return first rlp list in provided data, plus remaining data starting from the end of this list
-   */
-  public static DecodedList decodeFirstList(Bytes data) {
-    int len = RlpUtil.calcListLen(data);
-    return new DecodedList(RlpDecoder.decode(data.slice(0, len).toArray()), data.slice(len));
-  }
-
-  /**
-   * Decodes strictly the list of byte strings of specified lengths The list should contain strictly
-   * {@code lengths.length} strings
-   *
-   * @param constraints constrains for every string in the list
-   * @throws RlpDecodeException if this rlp doesn't represent a single list of strings of specified
-   *     lengths
-   */
-  public static List<Bytes> decodeListOfStrings(Bytes rlp, BytesConstraint... constraints)
-      throws RlpDecodeException {
-
-    List<Bytes> bytesList = decodeListOfStrings(rlp);
-    if (bytesList.size() != constraints.length) {
-      throw new RlpDecodeException("Expected RLP list of " + constraints.length + " items: " + rlp);
-    }
-
-    for (int i = 0; i < constraints.length; i++) {
-      if (!constraints[i].test(bytesList.get(i))) {
-        throw new RlpDecodeException(
-            "Failed constraints check (" + constraints[i] + ") for item #" + i + ": " + rlp);
-      }
-    }
-    return bytesList;
-  }
-
-  /**
-   * Decodes strictly the list of byte strings
-   *
-   * @throws RlpDecodeException if this rlp doesn't represent a single list of strings
-   */
-  public static List<Bytes> decodeListOfStrings(Bytes rlp) throws RlpDecodeException {
-    List<RlpType> values = decodeSingleList(rlp);
-
-    List<Bytes> ret = new ArrayList<>();
-    for (RlpType val : values) {
-      if (!(val instanceof RlpString)) {
-        throw new RlpDecodeException("Expected RLP list of strings only: " + rlp);
-      }
-      Bytes string = Bytes.wrap(((RlpString) val).getBytes());
-      ret.add(string);
-    }
-    return ret;
-  }
-
-  /**
-   * Decodes strictly one list from rlp bytes
-   *
-   * @throws RlpDecodeException if this rlp doesn't represent a single list
-   */
-  public static List<RlpType> decodeSingleList(Bytes rlp) throws RlpDecodeException {
-    return asList(decodeSingleItem(rlp));
-  }
-
-  public static List<RlpType> asList(RlpType item) throws RlpDecodeException {
-    if (!(item instanceof RlpList)) {
-      throw new RlpDecodeException("Expected RLP list, but got a string: " + item);
-    }
-    return ((RlpList) item).getValues();
-  }
-
-  public static int asInteger(RlpType item) throws RlpDecodeException {
-    Bytes bytes = asString(item, maxSize(4));
-    long l = bytes.toLong();
-    if (l > Integer.MAX_VALUE) {
-      throw new RlpDecodeException("Too large for integer: " + item);
-    }
-    return (int) l;
-  }
-
-  public static Bytes asString(RlpType item, BytesConstraint constraint) throws RlpDecodeException {
-    if (!(item instanceof RlpString)) {
-      throw new RlpDecodeException("Expected RLP bytes string, but got a list: " + item);
-    }
-    Bytes ret = Bytes.wrap(((RlpString) item).getBytes());
-    if (!constraint.test(ret)) {
-      throw new RlpDecodeException("The RLP string violates constraint: " + ret);
-    }
-    return ret;
-  }
-
-  /**
-   * Decodes strictly one bytes string item from rlp bytes
-   *
-   * @throws RlpDecodeException if this rlp doesn't represent a single bytes string
-   */
-  public static Bytes decodeSingleString(Bytes rlp) throws RlpDecodeException {
-    return asString(decodeSingleItem(rlp), CONS_ANY);
-  }
-
-  /**
-   * Decodes strictly one item from rlp bytes
-   *
-   * @throws RlpDecodeException if more that item encoded in this rlp
-   */
-  public static RlpType decodeSingleItem(Bytes rlp) throws RlpDecodeException {
-    try {
-      List<RlpType> rlpList = RlpDecoder.decode(rlp.toArray()).getValues();
-      if (rlpList.size() != 1) {
-        throw new RlpDecodeException("Only a single RLP item expected from bytes: " + rlp);
-      }
-      return rlpList.get(0);
-    } catch (Exception e) {
-      throw new RlpDecodeException("Error decoding RLP: " + rlp, e);
-    }
-  }
-
-  /**
-   * Encodes object to {@link RlpString}. Supports numbers, {@link Bytes} etc.
-   *
-   * @throws RuntimeException with errorMessageFunction applied with `object` when encoding is not
-   *     possible
-   */
-  public static RlpType encode(Object object, Function<Object, String> errorMessageFunction) {
-    if (object instanceof Bytes) {
-      return fromBytesValue((Bytes) object);
-    } else if (object instanceof Number) {
-      return fromNumber((Number) object);
-    } else if (object == null) {
-      return RlpString.create(new byte[0]);
-    } else if (object instanceof IdentitySchema) {
-      return RlpString.create(((IdentitySchema) object).stringName());
-    } else if (object instanceof List) {
-      return fromList((List<?>) object, errorMessageFunction);
-    } else {
-      throw new RuntimeException(errorMessageFunction.apply(object));
-    }
-  }
-
-  private static RlpList fromList(List<?> object, Function<Object, String> errorMessageFunction) {
-    return new RlpList(
-        object.stream().map(o -> encode(o, errorMessageFunction)).toArray(RlpType[]::new));
-  }
-
-  private static RlpString fromNumber(Number number) {
-    if (number instanceof BigInteger) {
-      return RlpString.create((BigInteger) number);
-    } else if (number instanceof Long) {
-      return RlpString.create((Long) number);
-    } else if (number instanceof Integer) {
-      return RlpString.create((Integer) number);
-    } else {
-      throw new RuntimeException(
-          String.format("Couldn't serialize number %s : no serializer found.", number));
-    }
-  }
-
-  private static RlpString fromBytesValue(Bytes bytes) {
-    return RlpString.create(bytes.toArray());
-  }
-
-  public static class DecodedList {
-    private final RlpList list;
-    private final Bytes remainingData;
-
-    public DecodedList(final RlpList list, final Bytes remainingData) {
-      this.list = list;
-      this.remainingData = remainingData;
-    }
-
-    public RlpList getList() {
-      return list;
-    }
-
-    public Bytes getRemainingData() {
-      return remainingData;
-    }
+  public static <T> T readRlpList(final Bytes rlp, final Function<RLPReader, T> fn) {
+    return RLP.decode(
+        rlp,
+        reader -> {
+          final T result = reader.readList(fn);
+          checkComplete(reader);
+          return result;
+        });
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -202,18 +202,18 @@ public class NodeRecordTest {
   public void testEnrWithEthFieldDecodes() {
     final int port = 30303;
     final Bytes ip = Bytes.fromHexString("0x7F000001");
-    final Bytes nodeId =
-        Bytes.fromHexString("a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7");
     final Bytes privateKey =
         Bytes.fromHexString("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+
     final List<Bytes> forkIdList = new ArrayList<>();
     forkIdList.add(Bytes.fromHexString("0x7a739ef1"));
     forkIdList.add(Bytes.fromHexString("0x"));
+
     final NodeRecord record =
         NODE_RECORD_FACTORY.createFromValues(
             UInt64.ONE,
             new EnrField(EnrField.ID, IdentitySchema.V4),
-            new EnrField(EnrField.PKEY_SECP256K1, nodeId),
+            new EnrField(EnrField.PKEY_SECP256K1, Functions.derivePublicKeyFromPrivate(privateKey)),
             new EnrField(EnrField.IP_V4, ip),
             new EnrField(EnrField.TCP, port),
             new EnrField("eth", Collections.singletonList(forkIdList)));
@@ -224,8 +224,20 @@ public class NodeRecordTest {
     assertThat(result).isEqualTo(record);
     assertThat(result.asEnr())
         .isEqualTo(
-            "enr:-I-4QN2E5eqaGOEaXAOdceWIep5oUHalCBvzWSH108iKhF6gAdoeBhp4V6nr71xSEaWrs_2Of6ZRhoxQh2"
-                + "2TAGE3H1gBg2V0aMfGhHpznvGAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoKRI8kxtGOV1RT2xMXFWK3"
-                + "GZmHPbWyht-VevGZ7JRhf3g3RjcIJ2Xw");
+            "enr:-JC4QBF-k6ezIoeB4BTMx9sLpFmcTZT4nBGUZLJ0JeYlT_rtfpVIa02sdfJwjUcXCb1h_HwGUtgPwwz2cbJiyAP4wT4Bg2V0aMfGhHpznvGAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN0Y3CCdl8");
+    final NodeRecord nodeRecord = NODE_RECORD_FACTORY.fromEnr(result.asEnr());
+    assertThat(nodeRecord.isValid()).isTrue();
+    assertThat(nodeRecord.get("eth")).isEqualTo(Collections.singletonList(forkIdList));
+    assertThat(nodeRecord).isEqualTo(result);
+  }
+
+  @Test
+  void testEnrWithValidEthFieldDecodes() {
+    final String enr =
+        "enr:-KK4QH0RsNJmIG0EX9LSnVxMvg-CAOr3ZFF92hunU63uE7wcYBjG1cFbUTvEa5G_4nDJkRhUq9q2ck9xY-VX1RtBsruBtIRldGgykIL0pysBABAg__________-CaWSCdjSCaXCEEnXQ0YlzZWNwMjU2azGhA1grTzOdMgBvjNrk-vqWtTZsYQIi0QawrhoZrsn5Hd56g3RjcIIjKIN1ZHCCIyg";
+    final NodeRecord nodeRecord = NODE_RECORD_FACTORY.fromEnr(enr);
+    assertThat(nodeRecord.asEnr()).isEqualTo(enr);
+    assertThat(nodeRecord.get("eth2"))
+        .isEqualTo(Bytes.fromHexString("0x82f4a72b01001020ffffffffffffffff"));
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.util.RlpDecodeException;
+import org.junit.jupiter.api.Test;
+
+class FindNodeMessageTest {
+
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(new NodeRecordFactory(new SimpleIdentitySchemaInterpreter()));
+
+  @Test
+  void shouldRoundTripViaRlp() {
+    final FindNodeMessage message =
+        new FindNodeMessage(Bytes.fromHexString("0x134488556699"), List.of(1, 2, 3, 4, 6, 9, 10));
+    final Bytes rlp = message.getBytes();
+    final FindNodeMessage result = (FindNodeMessage) decoder.decode(rlp);
+    assertThat(result).isEqualTo(message);
+  }
+
+  @Test
+  void shouldRejectTrailingBytes() {
+    final FindNodeMessage message =
+        new FindNodeMessage(Bytes.fromHexString("0x134488556699"), List.of(1, 2, 3, 4, 6, 9, 10));
+    final Bytes rlp = Bytes.concatenate(message.getBytes(), Bytes.fromHexString("0x1234"));
+    assertThatThrownBy(() -> decoder.decode(rlp)).isInstanceOf(RlpDecodeException.class);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/NodesMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/NodesMessageTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.junit.jupiter.api.Test;
+
+class NodesMessageTest {
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(NodeRecordFactory.DEFAULT);
+
+  @Test
+  void shouldRoundTrip() {
+    final NodesMessage original =
+        new NodesMessage(
+            Bytes.fromHexString("0x85482293"),
+            8,
+            List.of(
+                NodeRecordFactory.DEFAULT.fromEnr(
+                    "enr:-KK4QH0RsNJmIG0EX9LSnVxMvg-CAOr3ZFF92hunU63uE7wcYBjG1cFbUTvEa5G_4nDJkRhUq9q2ck9xY-VX1RtBsruBtIRldGgykIL0pysBABAg__________-CaWSCdjSCaXCEEnXQ0YlzZWNwMjU2azGhA1grTzOdMgBvjNrk-vqWtTZsYQIi0QawrhoZrsn5Hd56g3RjcIIjKIN1ZHCCIyg"),
+                NodeRecordFactory.DEFAULT.fromEnr(
+                    "enr:-LK4QH1xnjotgXwg25IDPjrqRGFnH1ScgNHA3dv1Z8xHCp4uP3N3Jjl_aYv_WIxQRdwZvSukzbwspXZ7JjpldyeVDzMCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpB53wQoAAAQIP__________gmlkgnY0gmlwhIe1te-Jc2VjcDI1NmsxoQOkcGXqbCJYbcClZ3z5f6NWhX_1YPFRYRRWQpJjwSHpVIN0Y3CCIyiDdWRwgiMo")));
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/PingMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/PingMessageTest.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.junit.jupiter.api.Test;
+
+class PingMessageTest {
+
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(NodeRecordFactory.DEFAULT);
+
+  @Test
+  void shouldRoundTrip() {
+    final PingMessage original =
+        new PingMessage(Bytes.fromHexString("0x85482293"), UInt64.MAX_VALUE);
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/PongMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/PongMessageTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.util.RlpDecodeException;
+import org.junit.jupiter.api.Test;
+
+class PongMessageTest {
+
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(NodeRecordFactory.DEFAULT);
+
+  @Test
+  void shouldRoundTripIpv4() {
+    final PongMessage original =
+        new PongMessage(
+            Bytes.fromHexString("0x85482293"),
+            UInt64.MAX_VALUE.subtract(1),
+            Bytes.fromHexString("0x12121212"),
+            48);
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+
+  @Test
+  void shouldRoundTripIpv6() {
+    final PongMessage original =
+        new PongMessage(
+            Bytes.fromHexString("0x85482293"),
+            UInt64.MAX_VALUE.subtract(1),
+            Bytes.fromHexString("0x12121212121212121212121212121212"),
+            48);
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+
+  @Test
+  void shouldFailDecodingWhenIpHasIncorrectNumberOfBytes() {
+    final PongMessage original =
+        new PongMessage(
+            Bytes.fromHexString("0x85482293"),
+            UInt64.MAX_VALUE.subtract(1),
+            Bytes.fromHexString("0x12"),
+            48);
+
+    final Bytes rlp = original.getBytes();
+    assertThatThrownBy(() -> decoder.decode(rlp)).isInstanceOf(RlpDecodeException.class);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/TalkReqMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/TalkReqMessageTest.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.junit.jupiter.api.Test;
+
+class TalkReqMessageTest {
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(NodeRecordFactory.DEFAULT);
+
+  @Test
+  void shouldRoundTrip() {
+    final TalkReqMessage original =
+        new TalkReqMessage(
+            Bytes.fromHexString("0x85482293"),
+            Bytes.fromHexString("0x12345678"),
+            Bytes.fromHexString("0x9876543231"));
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/message/TalkRespMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/TalkRespMessageTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.junit.jupiter.api.Test;
+
+class TalkRespMessageTest {
+
+  private final DiscoveryV5MessageDecoder decoder =
+      new DiscoveryV5MessageDecoder(NodeRecordFactory.DEFAULT);
+
+  @Test
+  void shouldRoundTrip() {
+    final TalkRespMessage original =
+        new TalkRespMessage(Bytes.fromHexString("0x85482293"), Bytes.fromHexString("0x9876543231"));
+
+    final Bytes rlp = original.getBytes();
+    final Message result = decoder.decode(rlp);
+    assertThat(result).isEqualTo(original);
+    assertThat(result.getBytes()).isEqualTo(rlp);
+  }
+}


### PR DESCRIPTION
## PR Description
Switches RLP parsing from webj3 to tuweni-rlp to avoid needing to parse into an intermediate representation before creating the internal types.
