### PR TITLE
Add ignore list for nodes to avoid quick recheck after failed livenes…

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -57,7 +57,8 @@ public class DiscoverySystemBuilder {
   private TalkHandler talkHandler = TalkHandler.NOOP;
   private NettyDiscoveryServer discoveryServer = null;
   private ExternalAddressSelector externalAddressSelector = null;
-  private final LivenessChecker livenessChecker = new LivenessChecker();
+  private final Clock clock = Clock.systemUTC();
+  private final LivenessChecker livenessChecker = new LivenessChecker(clock);
 
   public DiscoverySystemBuilder trafficReadLimit(final int trafficReadLimit) {
     this.trafficReadLimit = trafficReadLimit;
@@ -176,8 +177,7 @@ public class DiscoverySystemBuilder {
                     localNodeRecord, privateKey, localNodeRecordListener, newAddressHandler));
     nodeBucketStorage =
         requireNonNullElseGet(
-            nodeBucketStorage,
-            () -> new KBuckets(Clock.systemUTC(), localNodeRecordStore, livenessChecker));
+            nodeBucketStorage, () -> new KBuckets(clock, localNodeRecordStore, livenessChecker));
     expirationSchedulerFactory =
         requireNonNullElseGet(
             expirationSchedulerFactory,

--- a/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
+++ b/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 import kotlin.Pair;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Set-alike collection with data expiring in configured time. This structure is not thread safe,
@@ -104,7 +103,7 @@ public class ExpirationSet<V extends Comparable<V>> {
     return true;
   }
 
-  public boolean addAll(@NotNull Collection<? extends V> c) {
+  public boolean addAll(Collection<? extends V> c) {
     clearExpired();
     c.forEach(this::add);
     return true;

--- a/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
+++ b/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.database;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+import kotlin.Pair;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Set with data expiring in configured time
+ *
+ * @param <V> data type
+ */
+public class ExpirationSet<V> implements Set<V> {
+
+  private final long expirationDelayMillis;
+  private final Clock clock;
+  private final long size;
+
+  TreeSet<Pair<Long, V>> dataExpiration =
+      new TreeSet<>(
+          (o1, o2) -> {
+            int expirationDeltaSignum = Long.signum(o1.getFirst() - o2.getFirst());
+            if (expirationDeltaSignum != 0) {
+              return expirationDeltaSignum;
+            }
+            return Integer.compare(o1.getSecond().hashCode(), o2.getSecond().hashCode());
+          });
+  Set<V> data = new HashSet<>();
+
+  /**
+   * Creates new set with records expiring in configured timeline after insertion
+   *
+   * @param expirationDelayMillis Expiration delay, each record will be removed after this time
+   * @param clock Clock instance
+   * @param size Maximum size of a set, the oldest records will be removed to store new
+   */
+  public ExpirationSet(final long expirationDelayMillis, final Clock clock, final long size) {
+    this.expirationDelayMillis = expirationDelayMillis;
+    this.clock = clock;
+    if (size < 1) {
+      throw new RuntimeException("Minimal size is 1");
+    }
+    this.size = size;
+  }
+
+  /**
+   * Creates new set with records expiring in configured timeline after insertion
+   *
+   * @param expirationDelay Expiration delay, each record will be removed after this time
+   * @param clock Clock instance
+   * @param size Maximum size of a set, the oldest records will be removed to store new
+   */
+  public ExpirationSet(final Duration expirationDelay, final Clock clock, final long size) {
+    this(expirationDelay.toMillis(), clock, size);
+  }
+
+  private synchronized void clearExpired() {
+    final long currentTime = clock.millis();
+    boolean next = true;
+    while (next && !dataExpiration.isEmpty()) {
+      Pair<Long, V> last = dataExpiration.last();
+      if (last.getFirst() < currentTime) {
+        dataExpiration.remove(last);
+        data.remove(last.getSecond());
+      } else {
+        next = false;
+      }
+    }
+  }
+
+  @Override
+  public int size() {
+    clearExpired();
+    return data.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    clearExpired();
+    return data.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    clearExpired();
+    return data.contains(o);
+  }
+
+  @NotNull
+  @Override
+  public Iterator<V> iterator() {
+    clearExpired();
+    return data.iterator();
+  }
+
+  @NotNull
+  @Override
+  public Object[] toArray() {
+    clearExpired();
+    return data.toArray();
+  }
+
+  @NotNull
+  @Override
+  public <T> T[] toArray(@NotNull T[] a) {
+    throw new RuntimeException("Not implemented yet");
+  }
+
+  @Override
+  public synchronized boolean add(V v) {
+    clearExpired();
+    // no renewal
+    if (contains(v)) {
+      return false;
+    }
+    while (data.size() >= size) {
+      Pair<Long, V> last = dataExpiration.last();
+      dataExpiration.remove(last);
+      data.remove(last.getSecond());
+    }
+    dataExpiration.add(new Pair<>(clock.millis() + expirationDelayMillis, v));
+    data.add(v);
+    return true;
+  }
+
+  @Override
+  public synchronized boolean remove(Object o) {
+    throw new RuntimeException("Not implemented yet");
+  }
+
+  @Override
+  public boolean containsAll(@NotNull Collection<?> c) {
+    return data.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(@NotNull Collection<? extends V> c) {
+    clearExpired();
+    c.forEach(this::add);
+    return true;
+  }
+
+  @Override
+  public boolean retainAll(@NotNull Collection<?> c) {
+    throw new RuntimeException("Not implemented yet");
+  }
+
+  @Override
+  public boolean removeAll(@NotNull Collection<?> c) {
+    throw new RuntimeException("Not implemented yet");
+  }
+
+  @Override
+  public synchronized void clear() {
+    data.clear();
+    dataExpiration.clear();
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
@@ -75,6 +75,9 @@ class KBucket {
   }
 
   private void offerNewNode(final NodeRecord node) {
+    if (livenessChecker.isABadPeer(node)) {
+      return;
+    }
     if (isFull()) {
       getLastNode().checkLiveness(clock.millis());
       if (pendingNode.isEmpty()) {

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -44,8 +44,8 @@ public class DiscoveryNetworkTest {
     NodeInfo nodePair2 = TestUtil.generateNode(30304);
     NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
     NodeRecord nodeRecord2 = nodePair2.getNodeRecord();
-    LivenessChecker livenessChecker1 = new LivenessChecker();
-    LivenessChecker livenessChecker2 = new LivenessChecker();
+    LivenessChecker livenessChecker1 = new LivenessChecker(clock);
+    LivenessChecker livenessChecker2 = new LivenessChecker(clock);
     KBuckets nodeBucketStorage1 =
         new KBuckets(
             clock,

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -72,13 +72,12 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"DoubleBraceInitialization"})
 public class HandshakeHandlersTest {
-
-  Random rnd = new Random(1);
+  private final Random rnd = new Random(1);
+  private final Clock clock = Clock.systemUTC();
 
   @Test
   @SuppressWarnings("rawtypes")
   public void authHandlerWithMessageRoundTripTest() throws Exception {
-    final Clock clock = Clock.systemUTC();
     // Node1
     NodeInfo nodePair1 = TestUtil.generateUnverifiedNode(30303);
     NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
@@ -92,13 +91,13 @@ public class HandshakeHandlersTest {
             NodeRecordListener.NOOP,
             NewAddressHandler.NOOP);
     KBuckets nodeBucketStorage1 =
-        new KBuckets(clock, localNodeRecordStoreAt1, new LivenessChecker());
+        new KBuckets(clock, localNodeRecordStoreAt1, new LivenessChecker(clock));
     KBuckets nodeBucketStorage2 =
         new KBuckets(
             clock,
             new LocalNodeRecordStore(
                 nodeRecord2, Bytes.EMPTY, NodeRecordListener.NOOP, NewAddressHandler.NOOP),
-            new LivenessChecker());
+            new LivenessChecker(clock));
 
     // Node1 create AuthHeaderPacket
     LinkedBlockingQueue<RawPacket> outgoing1Packets = new LinkedBlockingQueue<>();

--- a/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
@@ -1,0 +1,52 @@
+package org.ethereum.beacon.discovery.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import org.junit.jupiter.api.Test;
+
+public class ExpirationSetTest {
+  private final Clock clock = mock(Clock.class);
+
+  @Test
+  public void shouldAppreciateSize() {
+    when(clock.millis()).thenReturn(12345L);
+    ExpirationSet<String> expirationSet = new ExpirationSet<>(1, clock, 3);
+    expirationSet.add("a");
+    expirationSet.add("b");
+    expirationSet.add("c");
+    expirationSet.add("d");
+    assertThat(expirationSet.size()).isEqualTo(3);
+    assertThat(expirationSet.contains("d")).isTrue();
+  }
+
+  @Test
+  public void oldElementsShouldExpire() {
+    when(clock.millis()).thenReturn(12345L);
+    ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
+    expirationSet.add("a");
+    expirationSet.add("b");
+    when(clock.millis()).thenReturn(12352L);
+    expirationSet.add("c");
+    when(clock.millis()).thenReturn(12355L);
+    expirationSet.add("d");
+    assertThat(expirationSet.size()).isEqualTo(2);
+    assertThat(expirationSet.contains("c")).isTrue();
+    assertThat(expirationSet.contains("d")).isTrue();
+  }
+
+  @Test
+  public void addingExistingElementShouldBeIgnore() {
+    when(clock.millis()).thenReturn(12345L);
+    ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
+    expirationSet.add("a");
+    when(clock.millis()).thenReturn(12349L);
+    expirationSet.add("a");
+    assertThat(expirationSet.size()).isEqualTo(1);
+    when(clock.millis()).thenReturn(12351L);
+    assertThat(expirationSet.size()).isEqualTo(0);
+    assertThat(expirationSet.contains("a")).isFalse();
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
@@ -32,8 +32,10 @@ public class ExpirationSetTest {
     ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
     expirationSet.add("a");
     expirationSet.add("b");
+    assertThat(expirationSet.size()).isEqualTo(2);
     when(clock.millis()).thenReturn(12352L);
     expirationSet.add("c");
+    assertThat(expirationSet.size()).isEqualTo(1);
     when(clock.millis()).thenReturn(12355L);
     expirationSet.add("d");
     assertThat(expirationSet.size()).isEqualTo(2);
@@ -42,7 +44,7 @@ public class ExpirationSetTest {
   }
 
   @Test
-  public void addingExistingElementShouldBeIgnore() {
+  public void addingExistingElementShouldBeIgnored() {
     when(clock.millis()).thenReturn(12345L);
     ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
     expirationSet.add("a");

--- a/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.ethereum.beacon.discovery.database;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/ethereum/beacon/discovery/liveness/LivenessCheckerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/liveness/LivenessCheckerTest.java
@@ -178,7 +178,7 @@ class LivenessCheckerTest {
     // there was 1 already above, but no second ping
     verify(pinger, times(1)).ping(node3);
 
-    when(mockClock.millis()).thenReturn(13345L + LivenessChecker.ignoreDuration.toMillis());
+    when(mockClock.millis()).thenReturn(13345L + LivenessChecker.IGNORE_DURATION.toMillis());
     livenessCheckerCustom.checkLiveness(node3);
     verify(pinger, times(2)).ping(node3);
   }


### PR DESCRIPTION
…s check

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description
Ignore table for peers, after peer fails to response on liveness check, it's added to ignore table for 30 seconds. During this period it's not added to the buckets and no rechecks are running for it.
I don't like the way I check this in `KBucket` but current architecture is weird and there is a big part of my miscount in it. I definitely want to see `SafeFuture` there one day.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Should fix #124