### PR TITLE
Reduce verbosity for `NodeSession` debug logs

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -185,7 +185,7 @@ public class NodeSession {
     requestExpirationScheduler.put(
         wrappedId,
         () -> {
-          logger.debug(
+          logger.trace(
               () ->
                   String.format(
                       "Request %s expired for id %s in session %s: no reply",
@@ -351,7 +351,7 @@ public class NodeSession {
   }
 
   public synchronized void setState(final SessionState newStatus) {
-    logger.debug(
+    logger.trace(
         () -> String.format("Switching status of node %s from %s to %s", nodeId, state, newStatus));
     this.state = newStatus;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

A couple of log lines make too much unnecessary noise in log with `DEBUG` level. 
Switch them to the `TRACE` level 

