### PR TITLE
Handle null return from grgit.describe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,6 +225,9 @@ def calculateVersion() {
     return 'UNKNOWN'
   }
   String version = grgit.describe(tags: true)
+  if (version == null) {
+    return "UNKNOWN+g${grgit.head().abbreviatedId}"
+  }
   def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
   def matcher = version =~ versionPattern
   if (matcher.find()) {


### PR DESCRIPTION
## PR Description

When building this project, I encountered the following issue:

```
$ ./gradlew build

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/jtraglia/Projects/jtraglia/discv5-java/build.gradle' line: 214

* What went wrong:
A problem occurred evaluating root project 'discovery'.
> Cannot invoke method contains() on null object
```

The return value of `grgit.describe` is `null` and this is causing problems.

This PR copies what Teku does in `calculateVersion`:

* https://github.com/ConsenSys/teku/blob/master/build.gradle#L938-L940
