### PR TITLE
Fix DiscoveryNetworkTest on macOS

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -76,6 +76,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
     bindFuture.addListener(
         result -> {
           if (!result.isSuccess()) {
+            logger.error("Problem binding to listen address", result.cause());
             future.completeExceptionally(result.cause());
             return;
           }

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -39,8 +39,9 @@ public class DiscoveryNetworkTest {
   public void test() throws Exception {
     final Clock clock = Clock.systemUTC();
     // 1) start 2 nodes
-    NodeInfo nodePair1 = TestUtil.generateNode(30303);
-    NodeInfo nodePair2 = TestUtil.generateNode(30304);
+    // note: not using port 30303 because of binding issues with macOS.
+    NodeInfo nodePair1 = TestUtil.generateNode(30304);
+    NodeInfo nodePair2 = TestUtil.generateNode(30305);
     NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
     NodeRecord nodeRecord2 = nodePair2.getNodeRecord();
     LivenessChecker livenessChecker1 = new LivenessChecker(clock);


### PR DESCRIPTION
## PR Description

Kept running into an issue with `DiscoveryNetworkTest#test` (it would fail 100% of the time) so I decided to look into it. It was a binding issue (`java.net.BindException: Address already in use`). This is pretty common issue with macOS. It seems to hold onto ports for longer. May be a result of me testing Ethereum clients on the machine a while ago. A simple solution was just to change the port numbers to something else that's probably not taken.

* Call `logging.error` when there's a binding issue.
* Change ports from `30303` & `30304` to `30304` & `30305`, respectively.

## Fixed Issue(s)

Fixes #73.