### PR TITLE
Ensure pong response recipient port is a uint16

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/PongMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/PongMessage.java
@@ -4,13 +4,16 @@
 
 package org.ethereum.beacon.discovery.message;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.ethereum.beacon.discovery.util.RlpUtil.checkMaxSize;
 import static org.ethereum.beacon.discovery.util.RlpUtil.checkSizeEither;
+import static org.ethereum.beacon.discovery.util.Utils.isPortValid;
 
 import com.google.common.base.Objects;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.rlp.RLP;
 import org.apache.tuweni.units.bigints.UInt64;
+import org.ethereum.beacon.discovery.util.RlpDecodeException;
 import org.ethereum.beacon.discovery.util.RlpUtil;
 
 /** PONG is the reply to PING {@link PingMessage} */
@@ -39,6 +42,9 @@ public class PongMessage implements V5Message {
           final UInt64 enrSeq = UInt64.valueOf(reader.readBigInteger());
           final Bytes recipientIp = checkSizeEither(reader.readValue(), 4, 16);
           final int recipientPort = reader.readInt();
+          if (!isPortValid(recipientPort)) {
+            throw new RlpDecodeException("Invalid port number");
+          }
           RlpUtil.checkComplete(reader);
           return new PongMessage(requestId, enrSeq, recipientIp, recipientPort);
         });

--- a/src/main/java/org/ethereum/beacon/discovery/util/Utils.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Utils.java
@@ -117,4 +117,8 @@ public class Utils {
     }
     return 0;
   }
+
+  public static boolean isPortValid(final int port) {
+    return (port >= 0 && port <= 65535);
+  }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/message/PongMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/PongMessageTest.java
@@ -60,4 +60,13 @@ class PongMessageTest {
     final Bytes rlp = original.getBytes();
     assertThatThrownBy(() -> decoder.decode(rlp)).isInstanceOf(RlpDecodeException.class);
   }
+
+  @Test
+  void shouldFailDecodingWhenPortIsInvalid() {
+    // The last 3 bytes is the important part. 0x010000 (65536) is UInt16.Max + 1.
+    final Bytes rlp = Bytes.fromHexString("0x02d7848548229388fffffffffffffffe841212121283010000");
+    assertThatThrownBy(() -> decoder.decode(rlp))
+        .isInstanceOf(RlpDecodeException.class)
+        .hasMessageContaining("Invalid port number");
+  }
 }


### PR DESCRIPTION
## PR Description

According to the spec, `recipient-port` is a (unsigned) 16-bit integer. But the implementation of `PongMessage` allowed any 32-bit integer to be used. I've added checks (`isPortValid` from Teku) to ensure its compliance.

* https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#pong-response-0x02

We could add checks to the constructor, but I don't think that's necessary. Maybe in a different PR.