### PR TITLE
Throw decoding exception if there's an invalid node distance

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/message/FindNodeMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/FindNodeMessage.java
@@ -38,13 +38,14 @@ public class FindNodeMessage implements V5Message {
   /**
    * According to the <a
    * href="https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#node-table">Node
-   * Discovery Protocol</a>, a distance must greater than or equal to zero and less than 256.
+   * Discovery Protocol</a>, there are 256 buckets and the 0th bucket is reserved for our node.
+   * Therefore, a distance must be greater than or equal to 0 and less than or equal to 256.
    *
    * @param distance The distance value to check.
    * @return True if the distance is valid.
    */
   public static boolean isValidDistance(final int distance) {
-    return 0 <= distance && distance < 256;
+    return 0 <= distance && distance <= 256;
   }
 
   public static FindNodeMessage fromBytes(Bytes bytes) throws DecodeException {

--- a/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
@@ -39,7 +39,7 @@ class FindNodeMessageTest {
   @Test
   void shouldRejectInvalidDistance() {
     final FindNodeMessage message =
-        new FindNodeMessage(Bytes.fromHexString("0x134488556699"), List.of(256));
+        new FindNodeMessage(Bytes.fromHexString("0x134488556699"), List.of(257));
     final Bytes rlp = message.getBytes();
     assertThatThrownBy(() -> decoder.decode(rlp))
         .isInstanceOf(RlpDecodeException.class)

--- a/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/FindNodeMessageTest.java
@@ -35,4 +35,14 @@ class FindNodeMessageTest {
     final Bytes rlp = Bytes.concatenate(message.getBytes(), Bytes.fromHexString("0x1234"));
     assertThatThrownBy(() -> decoder.decode(rlp)).isInstanceOf(RlpDecodeException.class);
   }
+
+  @Test
+  void shouldRejectInvalidDistance() {
+    final FindNodeMessage message =
+        new FindNodeMessage(Bytes.fromHexString("0x134488556699"), List.of(256));
+    final Bytes rlp = message.getBytes();
+    assertThatThrownBy(() -> decoder.decode(rlp))
+        .isInstanceOf(RlpDecodeException.class)
+        .hasMessageContaining("Invalid distance");
+  }
 }


### PR DESCRIPTION
## PR Description

According to the [spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#node-table), there are 256 buckets and 0 is reserved for our node, so a distance value can be in `[0, 256]`.

> For each `0 ≤ i < 256`, every node keeps a k-bucket for nodes of `logdistance(self, n) == I`. The Node Discovery Protocol uses `k = 16`, i.e. every k-bucket contains up to 16 node entries.

I see that this is enforced in the `KBuckets` class, but I think we should throw a decoding error if we receive a `FindNodeMessage` with an invalid distance. We could just ignore that distance, but I think we should ignore the message:

https://github.com/ConsenSys/discovery/blob/d780ba4642db8acd1a6a8253d9e86018eafb8b89/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java#L22-L29

Also, in my opinion, the spec is pretty vague about this detail. My first impression told me that a distance of 256 is invalid, but after I thought more about it, it seems valid. I'm still kind of confused though 🤷 