### PR TITLE
Update errorprone & do ConsenSys errorprone checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.41.0'
   id 'com.github.hierynomus.license' version '0.16.1'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'net.ltgt.errorprone' version '2.0.2'
+  id 'net.ltgt.errorprone' version '3.0.1'
   id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
@@ -23,6 +23,7 @@ targetCompatibility = '11'
 
 repositories {
   mavenCentral()
+  maven { url "https://artifacts.consensys.net/public/maven/maven/" }
 }
 
 dependencies {
@@ -47,6 +48,7 @@ dependencies {
   testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
   errorprone("com.google.errorprone:error_prone_core")
+  errorprone("tech.pegasys.tools.epchecks:errorprone-checks")
 }
 
 spotless {
@@ -91,25 +93,33 @@ tasks.withType(JavaCompile) {
 
   options.errorprone {
     disableWarningsInGeneratedCode
+
     // Our equals need to be symmetric, this checker doesn't respect that.
     check('EqualsGetClass', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
     // We like to use futures with no return values.
     check('FutureReturnValueIgnored', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
     // We use the JSR-305 annotations instead of the Google annotations.
     check('ImmutableEnumChecker', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
-
     check('FieldCanBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+    check('CanIgnoreReturnValueSuggester', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+
+    // These are experimental checks that we want enabled.
+    check('MissingBraces', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
     check('InsecureCryptoUsage', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
     check('WildcardImport', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('DeduplicateConstants', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('RedundantOverride', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('RedundantThrows', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('UnnecessarilyFullyQualified', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('InitializeInline', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('ClassName', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+    check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
 
-    // This check is broken in Java 12.  See https://github.com/google/error-prone/issues/1257
-    if (JavaVersion.current() == JavaVersion.VERSION_12) {
-      check('Finally', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
-    }
-    // This check is broken after Java 12.  See https://github.com/google/error-prone/issues/1352
-    if (JavaVersion.current() > JavaVersion.VERSION_12) {
-      check('TypeParameterUnusedInFormals', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
-    }
+    // These checks are imported from errorprone-checks dependency but not required.
+    check('MethodInputParametersMustBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+    check('BannedMethod', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+    check('JavaCase', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
   }
   options.encoding = 'UTF-8'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,11 +1,13 @@
 dependencyManagement {
   dependencies {
-    dependencySet(group: 'com.google.errorprone', version: '2.11.0') {
+    dependencySet(group: 'com.google.errorprone', version: '2.16') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'
       entry 'error_prone_test_helpers'
     }
+
+    dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.0'
 
     dependency 'com.google.guava:guava:31.0.1-jre'
 

--- a/src/main/java/org/ethereum/beacon/discovery/database/HoleyList.java
+++ b/src/main/java/org/ethereum/beacon/discovery/database/HoleyList.java
@@ -19,7 +19,9 @@ public class HoleyList<V> {
   private long size = 0;
 
   public void put(long idx, V value) {
-    if (value == null) return;
+    if (value == null) {
+      return;
+    }
     if (idx >= size()) {
       setSize(idx + 1);
     }
@@ -31,7 +33,9 @@ public class HoleyList<V> {
    * index
    */
   public Optional<V> get(long idx) {
-    if (idx < 0 || idx >= size()) return Optional.empty();
+    if (idx < 0 || idx >= size()) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(data.get(idx));
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/message/FindNodeMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/FindNodeMessage.java
@@ -72,8 +72,12 @@ public class FindNodeMessage implements V5Message {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     FindNodeMessage that = (FindNodeMessage) o;
     return Objects.equal(requestId, that.requestId)
         && Objects.equal(getDistances(), that.getDistances());

--- a/src/main/java/org/ethereum/beacon/discovery/message/PingMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/PingMessage.java
@@ -64,8 +64,12 @@ public class PingMessage implements V5Message {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     PingMessage that = (PingMessage) o;
     return Objects.equal(requestId, that.requestId) && Objects.equal(enrSeq, that.enrSeq);
   }

--- a/src/main/java/org/ethereum/beacon/discovery/message/PongMessage.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/PongMessage.java
@@ -81,8 +81,12 @@ public class PongMessage implements V5Message {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     PongMessage that = (PongMessage) o;
     return Objects.equal(requestId, that.requestId)
         && Objects.equal(enrSeq, that.enrSeq)

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/DelegatingReactorScheduler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/DelegatingReactorScheduler.java
@@ -10,9 +10,9 @@ import javax.annotation.Nonnull;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler;
 
-public class DelegatingReactorScheduler implements reactor.core.scheduler.Scheduler {
+public class DelegatingReactorScheduler implements Scheduler {
 
-  protected final reactor.core.scheduler.Scheduler delegate;
+  protected final Scheduler delegate;
   protected final Supplier<Long> timeSupplier;
 
   public DelegatingReactorScheduler(Scheduler delegate, Supplier<Long> timeSupplier) {

--- a/src/main/java/org/ethereum/beacon/discovery/util/CryptoUtil.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/CryptoUtil.java
@@ -30,6 +30,7 @@ public class CryptoUtil {
     return Bytes32.wrap(sha256Digest.digest());
   }
 
+  @SuppressWarnings("DoNotInvokeMessageDigestDirectly")
   private static MessageDigest getSha256Digest() {
     try {
       return MessageDigest.getInstance("sha256", securityProvider);

--- a/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
@@ -285,8 +285,12 @@ public class Functions {
 
     @Override
     public boolean equals(final Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
       HKDFKeys hkdfKeys = (HKDFKeys) o;
       return Objects.equal(initiatorKey, hkdfKeys.initiatorKey)
           && Objects.equal(recipientKey, hkdfKeys.recipientKey)


### PR DESCRIPTION
## PR Description

* Update errorprone to the latest version (`2.16`)
  * Btw it's a little annoying that `2.16.0` isn't valid yet.
* Update the errorprone gradle plugin to the latest version.
* Do checks from [`errorprone-checks`](https://github.com/ConsenSys/errorprone-checks) (by ConsenSys).
* Like Teku, suppress the one instance of `DoNotInvokeMessageDigestDirectly`.
* Like Teku, enable a variety of experimental checks that I think are good.
* Remove disabled checks for Java 12 that were broken.
  * I don't think this is an issue any more.
* Fix findings from `MissingBraces` and `UnnecessarilyFullyQualified`.
  * Will fix findings from `JavaCase` in a different PR.