### PR TITLE
Check for more required fields

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/HandlerUtil.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/HandlerUtil.java
@@ -24,7 +24,7 @@ public class HandlerUtil {
     }
   }
 
-  public static boolean requireNodeRecord(Envelope envelope) {
+  public static boolean requireSessionWithNodeRecord(Envelope envelope) {
     if (!requireField(Field.SESSION, envelope)) {
       return false;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
@@ -23,7 +23,7 @@ public class BadPacketHandler implements EnvelopeHandler {
     logger.trace(
         () ->
             String.format(
-                "Envelope %s in BadPacketLogger, requirements are satisfied!",
+                "Envelope %s in BadPacketHandler, requirements are satisfied!",
                 envelope.getIdString()));
 
     logger.debug(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -58,7 +58,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
     logger.trace(
         () ->
             String.format(
-                "Envelope %s in AuthHeaderMessagePacketHandler, requirements are satisfied!",
+                "Envelope %s in HandshakeMessagePacketHandler, requirements are satisfied!",
                 envelope.getIdString()));
 
     HandshakeMessagePacket packet = envelope.get(Field.PACKET_HANDSHAKE);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -40,9 +40,6 @@ public class MessageHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.MESSAGE, envelope)) {
       return;
     }
-    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
-      return;
-    }
     if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -40,6 +40,9 @@ public class MessageHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.MESSAGE, envelope)) {
       return;
     }
+    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
+      return;
+    }
     if (!HandlerUtil.requireNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -43,7 +43,7 @@ public class MessageHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }
-    if (!HandlerUtil.requireNodeRecord(envelope)) {
+    if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }
     logger.trace(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
@@ -47,9 +47,6 @@ public class NextTaskHandler implements EnvelopeHandler {
 
   @Override
   public void handle(Envelope envelope) {
-    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
-      return;
-    }
     if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
@@ -47,6 +47,9 @@ public class NextTaskHandler implements EnvelopeHandler {
 
   @Override
   public void handle(Envelope envelope) {
+    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
+      return;
+    }
     if (!HandlerUtil.requireNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
@@ -50,7 +50,7 @@ public class NextTaskHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }
-    if (!HandlerUtil.requireNodeRecord(envelope)) {
+    if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }
     logger.trace(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -75,7 +75,7 @@ public class NodeSessionManager implements EnvelopeHandler {
       return;
     }
     logger.trace(
-        "Envelope {} in NodeIdToSession, requirements are satisfied!", envelope.getIdString());
+        "Envelope {} in NodeSessionManager, requirements are satisfied!", envelope.getIdString());
 
     SessionLookup sessionRequest = envelope.get(Field.SESSION_LOOKUP);
     envelope.remove(Field.SESSION_LOOKUP);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
@@ -34,7 +34,7 @@ public class PacketDispatcherHandler implements EnvelopeHandler {
     logger.trace(
         () ->
             String.format(
-                "Envelope %s in UnknownPacketTypeByStatus, requirements are satisfied!",
+                "Envelope %s in PacketDispatcherHandler, requirements are satisfied!",
                 envelope.getIdString()));
 
     Packet<?> packet = envelope.get(Field.PACKET);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
@@ -37,7 +37,7 @@ public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
     logger.trace(
         () ->
             String.format(
-                "Envelope %s in NotExpectedIncomingPacketHandler, requirements are satisfied!",
+                "Envelope %s in UnauthorizedMessagePacketHandler, requirements are satisfied!",
                 envelope.getIdString()));
 
     NodeSession session = envelope.get(Field.SESSION);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -50,6 +50,12 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.PACKET_WHOAREYOU, envelope)) {
       return;
     }
+    if (!HandlerUtil.requireField(Field.MASKING_IV, envelope)) {
+      return;
+    }
+    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
+      return;
+    }
     logger.trace(
         () ->
             String.format(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -44,7 +44,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
 
   @Override
   public void handle(final Envelope envelope) {
-    if (!HandlerUtil.requireNodeRecord(envelope)) {
+    if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }
     if (!HandlerUtil.requireField(Field.PACKET_WHOAREYOU, envelope)) {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -51,7 +51,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
       return;
     }
     if (!HandlerUtil.requireField(Field.MASKING_IV, envelope)) {
-      return;
+      throw new IllegalStateException("Internal error: No MASKING_IV field for WhoAreYou packet");
     }
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
@@ -88,9 +88,6 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
 
       // The handshake uses the unmasked WHOAREYOU challenge as an input:
       // challenge-data     = masking-iv || static-header || authdata
-      if (!envelope.contains(Field.MASKING_IV)) {
-        throw new IllegalStateException("Internal error: No MASKING_IV field for WhoAreYou packet");
-      }
       Bytes16 whoAreYouMaskingIV = envelope.get(Field.MASKING_IV);
       Bytes challengeData =
           Bytes.wrap(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -53,9 +53,6 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.MASKING_IV, envelope)) {
       throw new IllegalStateException("Internal error: No MASKING_IV field for WhoAreYou packet");
     }
-    if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
-      return;
-    }
     LOG.trace(
         () ->
             String.format(


### PR DESCRIPTION
## PR Description

So for these handlers, I believe these fields should be required. As a rule of thumb, if `envelope.get(FIELD)` is called in the handler, `FIELD` should be required, right? For one instance, `MessageHandler`, all of the specific message handlers (`NodesHandler`, `PingHandler`, etc) seem to assume a valid session.
