### PR TITLE
Add shouldRejectInvalidTotalPackets test

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -15,10 +15,11 @@ import org.ethereum.beacon.discovery.util.Functions;
 
 public class FindNodeResponseHandler implements MultiPacketResponseHandler<NodesMessage> {
   private static final Logger logger = LogManager.getLogger(FindNodeResponseHandler.class);
+  private static final int NOT_SET = -1;
   private static final int MAX_TOTAL_PACKETS = 16;
   private final List<NodeRecord> foundNodes = new ArrayList<>();
   private final Collection<Integer> distances;
-  private int totalPackets = -1;
+  private int totalPackets = NOT_SET;
   private int receivedPackets = 0;
 
   public FindNodeResponseHandler(final Collection<Integer> distances) {
@@ -27,7 +28,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
 
   @Override
   public synchronized boolean handleResponseMessage(NodesMessage message, NodeSession session) {
-    if (totalPackets == -1) {
+    if (totalPackets == NOT_SET) {
       totalPackets = message.getTotal();
       if (totalPackets < 1 || totalPackets > MAX_TOTAL_PACKETS) {
         throw new RuntimeException("Invalid number of total packets: " + totalPackets);
@@ -47,8 +48,8 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
     logger.trace(
         () ->
             String.format(
-                "Received %s node records in session %s. Total buckets expected: %s",
-                message.getNodeRecords().size(), session, message.getTotal()));
+                "Received %s node records in session %s. Packet %s/%s.",
+                message.getNodeRecords().size(), session, receivedPackets, message.getTotal()));
     message.getNodeRecords().stream()
         .filter(this::isValid)
         .filter(record -> hasCorrectDistance(session, record))


### PR DESCRIPTION
## PR Description

Well I misinterpreted [the spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#nodes-response-0x04) and thought the following sentences meant that `FindNodeResponseHandler` should ignore excess packets, instead of rejecting the response, after the allowed maximum for total.

> Implementations may place a limit on the allowed maximum for total. If exceeded, additional responses may be ignored. 

I started to "fix" it but then I noticed that it said "additional responses" and not "additional packets". So I decided to add some tests to ensure that functionality works as expected. Also, updated two things in the handler that I thought helped readability. Should we ignore additional responses after a bad response?
