### PR TITLE
Make streamClosestNodes synchronized

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
@@ -80,7 +80,7 @@ public class KBuckets {
     }
   }
 
-  public Stream<NodeRecord> streamClosestNodes(Bytes nodeId) {
+  public synchronized Stream<NodeRecord> streamClosestNodes(Bytes nodeId) {
     return StreamSupport.stream(
         Spliterators.spliteratorUnknownSize(
             new KBucketsIterator(this, homeNodeId, nodeId), Spliterator.ORDERED),


### PR DESCRIPTION
## PR Description

Not 100% confident, but I think this method should be synchronized. Every other public method in this class is synchronized; this method was added after the others. `this` passed to `KBucketsIterator` could change during iteration.