### PR TITLE
Fix JavaCase findings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,10 +116,12 @@ tasks.withType(JavaCompile) {
     check('InterfaceWithOnlyStatics', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
     check('PackageLocation', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
 
+    // Force strict compliance with Java naming conventions.
+    check('JavaCase', net.ltgt.gradle.errorprone.CheckSeverity.WARN)
+
     // These checks are imported from errorprone-checks dependency but not required.
     check('MethodInputParametersMustBeFinal', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
     check('BannedMethod', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
-    check('JavaCase', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
   }
   options.encoding = 'UTF-8'
 

--- a/src/main/java/org/ethereum/beacon/discovery/message/MessageCode.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/MessageCode.java
@@ -61,11 +61,11 @@ public enum MessageCode {
    */
   TOPICQUERY(0x0A);
 
-  private static final Map<Integer, MessageCode> codeMap = new HashMap<>();
+  private static final Map<Integer, MessageCode> CODE_MAP = new HashMap<>();
 
   static {
     for (MessageCode type : MessageCode.values()) {
-      codeMap.put(type.code, type);
+      CODE_MAP.put(type.code, type);
     }
   }
 
@@ -76,7 +76,7 @@ public enum MessageCode {
   }
 
   public static MessageCode fromNumber(int i) {
-    return codeMap.get(i);
+    return CODE_MAP.get(i);
   }
 
   public byte byteCode() {

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/ExternalAddressSelector.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface ExternalAddressSelector {
 
-  ExternalAddressSelector NOOP = (_1, _2, _3) -> {};
+  ExternalAddressSelector NOOP = (a, b, c) -> {};
 
   void onExternalAddressReport(
       final Optional<InetSocketAddress> previouslyReportedAddress,

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/FindNodeHandler.java
@@ -18,7 +18,7 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 
 public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
-  private static final Logger logger = LogManager.getLogger(FindNodeHandler.class);
+  private static final Logger LOG = LogManager.getLogger(FindNodeHandler.class);
 
   /**
    * The maximum size of any packet is 1280 bytes. Implementations should not generate or process
@@ -50,7 +50,7 @@ public class FindNodeHandler implements MessageHandler<FindNodeMessage> {
     List<List<NodeRecord>> nodeRecordBatches =
         Lists.partition(nodeRecordInfos, MAX_NODES_PER_MESSAGE);
 
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Sending %s nodes in reply to request with distances %s in session %s",

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/PongHandler.java
@@ -16,7 +16,7 @@ import org.ethereum.beacon.discovery.message.PongMessage;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 
 public class PongHandler implements MessageHandler<PongMessage> {
-  private static final Logger logger = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   private final ExternalAddressSelector externalAddressSelector;
   private final EnrUpdateTracker enrUpdateTracker;
 
@@ -40,7 +40,7 @@ public class PongHandler implements MessageHandler<PongMessage> {
         externalAddressSelector.onExternalAddressReport(
             currentAddress, reportedAddress, Instant.now());
       } catch (UnknownHostException e) {
-        logger.trace("Failed to update local node record because recipient IP was invalid", e);
+        LOG.trace("Failed to update local node record because recipient IP was invalid", e);
       }
     }
     session.clearRequestInfo(message.getRequestId(), null);

--- a/src/main/java/org/ethereum/beacon/discovery/message/handler/TalkReqHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/message/handler/TalkReqHandler.java
@@ -15,7 +15,7 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 
 public class TalkReqHandler implements MessageHandler<TalkReqMessage> {
-  private static final Logger logger = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private final TalkHandler appTalkHandler;
 
@@ -36,7 +36,7 @@ public class TalkReqHandler implements MessageHandler<TalkReqMessage> {
             })
         .exceptionally(
             err -> {
-              logger.debug("Application TalkHandler completed with error", err);
+              LOG.debug("Application TalkHandler completed with error", err);
               return null;
             });
   }

--- a/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
@@ -18,7 +18,7 @@ import reactor.core.publisher.FluxSink;
  * could be later linked to processor to form incoming messages stream
  */
 public class IncomingMessageSink extends SimpleChannelInboundHandler<Envelope> {
-  private static final Logger logger = LogManager.getLogger(IncomingMessageSink.class);
+  private static final Logger LOG = LogManager.getLogger(IncomingMessageSink.class);
   private final FluxSink<Envelope> messageSink;
 
   public IncomingMessageSink(FluxSink<Envelope> messageSink) {
@@ -27,12 +27,12 @@ public class IncomingMessageSink extends SimpleChannelInboundHandler<Envelope> {
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, Envelope msg) {
-    logger.trace(() -> String.format("Incoming packet %s in session %s", msg, ctx));
+    LOG.trace(() -> String.format("Incoming packet %s in session %s", msg, ctx));
     messageSink.next(msg);
   }
 
   @Override
   public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
-    logger.error("Unexpected exception caught", cause);
+    LOG.error("Unexpected exception caught", cause);
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
@@ -16,7 +16,7 @@ import reactor.core.publisher.Flux;
 
 /** Netty discovery UDP client */
 public class NettyDiscoveryClientImpl implements DiscoveryClient {
-  private static final Logger logger = LogManager.getLogger(NettyDiscoveryClientImpl.class);
+  private static final Logger LOG = LogManager.getLogger(NettyDiscoveryClientImpl.class);
   private NioDatagramChannel channel;
 
   /**
@@ -32,7 +32,7 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
         .subscribe(
             networkPacket ->
                 send(networkPacket.getPacket().getBytes(), networkPacket.getDestination()));
-    logger.info("UDP discovery client started");
+    LOG.info("UDP discovery client started");
   }
 
   @Override
@@ -41,7 +41,7 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
   @Override
   public void send(Bytes data, InetSocketAddress destination) {
     DatagramPacket packet = new DatagramPacket(Unpooled.copiedBuffer(data.toArray()), destination);
-    logger.trace(() -> String.format("Sending packet %s", packet));
+    LOG.trace(() -> String.format("Sending packet %s", packet));
     channel.write(packet);
     channel.flush();
   }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.ReplayProcessor;
 
 public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
-  private static final Logger logger = LogManager.getLogger(NettyDiscoveryServerImpl.class);
+  private static final Logger LOG = LogManager.getLogger(NettyDiscoveryServerImpl.class);
   private static final int RECREATION_TIMEOUT = 5000;
   private final ReplayProcessor<Envelope> incomingPackets = ReplayProcessor.cacheLast();
   private final FluxSink<Envelope> incomingSink = incomingPackets.sink();
@@ -42,7 +42,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
 
   @Override
   public CompletableFuture<NioDatagramChannel> start() {
-    logger.info("Starting discovery server on UDP port {}", listenAddress.getPort());
+    LOG.info("Starting discovery server on UDP port {}", listenAddress.getPort());
     if (!listen.compareAndSet(false, true)) {
       return CompletableFuture.failedFuture(
           new IllegalStateException("Attempted to start an already started server"));
@@ -86,11 +86,11 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
               .addListener(
                   closeFuture -> {
                     if (!listen.get()) {
-                      logger.info("Shutting down discovery server");
+                      LOG.info("Shutting down discovery server");
                       group.shutdownGracefully();
                       return;
                     }
-                    logger.error(
+                    LOG.error(
                         "Discovery server closed. Trying to restore after "
                             + RECREATION_TIMEOUT
                             + " milliseconds delay",
@@ -111,23 +111,23 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
   @Override
   public void stop() {
     if (listen.compareAndSet(true, false)) {
-      logger.info("Stopping discovery server");
+      LOG.info("Stopping discovery server");
       if (channel != null) {
         try {
           channel.close().sync();
         } catch (InterruptedException ex) {
-          logger.error("Failed to stop discovery server", ex);
+          LOG.error("Failed to stop discovery server", ex);
         }
         if (nioGroup != null) {
           try {
             nioGroup.shutdownGracefully().sync();
           } catch (InterruptedException ex) {
-            logger.error("Failed to stop NIO group", ex);
+            LOG.error("Failed to stop NIO group", ex);
           }
         }
       }
     } else {
-      logger.warn("An attempt to stop already stopping/stopped discovery server");
+      LOG.warn("An attempt to stop already stopping/stopped discovery server");
     }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/HandlerUtil.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/HandlerUtil.java
@@ -9,13 +9,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class HandlerUtil {
-  private static final Logger logger = LogManager.getLogger(HandlerUtil.class);
+  private static final Logger LOG = LogManager.getLogger(HandlerUtil.class);
 
   public static boolean requireField(Field<?> field, Envelope envelope) {
     if (envelope.contains(field)) {
       return true;
     } else {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Requirement not satisfied: field %s not exists in envelope %s",
@@ -29,7 +29,7 @@ public class HandlerUtil {
       return false;
     }
     if (envelope.get(Field.SESSION).getNodeRecord().isEmpty()) {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Requirement not satisfied: node record unknown in envelope %s",
@@ -44,7 +44,7 @@ public class HandlerUtil {
     if (conditionFunction.apply(envelope)) {
       return true;
     } else {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Requirement not satisfied: condition %s not met for envelope %s",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
@@ -13,20 +13,20 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 
 /** Handles packet from {@link Field#BAD_PACKET}. Currently just logs it. */
 public class BadPacketHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(BadPacketHandler.class);
+  private static final Logger LOG = LogManager.getLogger(BadPacketHandler.class);
 
   @Override
   public void handle(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.BAD_PACKET, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in BadPacketLogger, requirements are satisfied!",
                 envelope.getIdString()));
 
-    logger.debug(
+    LOG.debug(
         () ->
             String.format(
                 "Bad packet: %s in envelope #%s: %s",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/IncomingDataPacker.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/IncomingDataPacker.java
@@ -18,7 +18,7 @@ import org.ethereum.beacon.discovery.util.DecodeException;
 
 /** Handles raw BytesValue incoming data in {@link Field#INCOMING} */
 public class IncomingDataPacker implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(IncomingDataPacker.class);
+  private static final Logger LOG = LogManager.getLogger(IncomingDataPacker.class);
   public static final int MAX_PACKET_SIZE = 1280;
   public static final int MIN_PACKET_SIZE = 63;
   private final Bytes16 homeNodeId;
@@ -32,7 +32,7 @@ public class IncomingDataPacker implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.INCOMING, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in IncomingDataPacker, requirements are satisfied!",
@@ -53,13 +53,13 @@ public class IncomingDataPacker implements EnvelopeHandler {
 
       envelope.put(Field.PACKET, packet);
       envelope.put(Field.MASKING_IV, rawPacket.getMaskingIV());
-      logger.trace(
+      LOG.trace(
           () ->
               String.format("Incoming packet %s in envelope #%s", packet, envelope.getIdString()));
     } catch (Exception ex) {
       envelope.put(Field.BAD_PACKET, rawPacketBytes);
       envelope.put(Field.BAD_EXCEPTION, ex);
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Bad incoming packet %s in envelope #%s",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -20,7 +20,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 
 public class MessageHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(MessageHandler.class);
+  private static final Logger LOG = LogManager.getLogger(MessageHandler.class);
   private final MessageProcessor messageProcessor;
 
   public MessageHandler(
@@ -43,7 +43,7 @@ public class MessageHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireNodeRecord(envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in MessageHandler, requirements are satisfied!",
@@ -54,7 +54,7 @@ public class MessageHandler implements EnvelopeHandler {
     try {
       messageProcessor.handleIncoming(message, session);
     } catch (Exception ex) {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Failed to handle message %s in envelope #%s", message, envelope.getIdString()),

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -20,7 +20,7 @@ import org.ethereum.beacon.discovery.util.DecryptException;
 
 /** Handles {@link MessagePacket} in {@link Field#PACKET_MESSAGE} field */
 public class MessagePacketHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(MessagePacketHandler.class);
+  private static final Logger LOG = LogManager.getLogger(MessagePacketHandler.class);
   private final NodeRecordFactory nodeRecordFactory;
 
   public MessagePacketHandler(NodeRecordFactory nodeRecordFactory) {
@@ -38,7 +38,7 @@ public class MessagePacketHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in MessagePacketHandler, requirements are satisfied!",
@@ -54,7 +54,7 @@ public class MessagePacketHandler implements EnvelopeHandler {
       envelope.put(Field.MESSAGE, message);
       envelope.remove(Field.PACKET_MESSAGE);
     } catch (DecryptException e) {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "Failed to decrypt message [%s] from node %s in status %s. Will be sending WHOAREYOU...",
@@ -69,11 +69,11 @@ public class MessagePacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, session.getNodeRecord(), session.getState());
-      logger.debug(error, ex);
+      LOG.debug(error, ex);
       envelope.remove(Field.PACKET_MESSAGE);
       envelope.put(Field.BAD_PACKET, packet);
     } catch (Throwable t) {
-      logger.warn(
+      LOG.warn(
           "Unexpected error while reading message [{}] from node {}",
           packet,
           session.getNodeRecord(),

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NewTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NewTaskHandler.java
@@ -15,7 +15,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
 
 /** Enqueues task in session for any task found in {@link Field#REQUEST} */
 public class NewTaskHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(NewTaskHandler.class);
+  private static final Logger LOG = LogManager.getLogger(NewTaskHandler.class);
 
   @Override
   @SuppressWarnings("rawtypes")
@@ -26,7 +26,7 @@ public class NewTaskHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in NewTaskHandler, requirements are satisfied!",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
@@ -24,7 +24,7 @@ import org.ethereum.beacon.discovery.task.TaskStatus;
 
 /** Gets next request task in session and processes it */
 public class NextTaskHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(NextTaskHandler.class);
+  private static final Logger LOG = LogManager.getLogger(NextTaskHandler.class);
   private static final int DEFAULT_DELAY_MS = 1000;
   private static final int RANDOM_MESSAGE_SIZE = 128;
   private final Pipeline outgoingPipeline;
@@ -50,7 +50,7 @@ public class NextTaskHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireNodeRecord(envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in NextTaskHandler, requirements are satisfied!",
@@ -59,13 +59,12 @@ public class NextTaskHandler implements EnvelopeHandler {
     NodeSession session = envelope.get(Field.SESSION);
     Optional<RequestInfo> requestInfoOpt = session.getFirstAwaitRequestInfo();
     if (requestInfoOpt.isEmpty()) {
-      logger.trace(
-          () -> String.format("Envelope %s: no awaiting requests", envelope.getIdString()));
+      LOG.trace(() -> String.format("Envelope %s: no awaiting requests", envelope.getIdString()));
       return;
     }
 
     RequestInfo requestInfo = requestInfoOpt.get();
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s: processing awaiting request %s",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -40,7 +40,7 @@ import org.ethereum.beacon.discovery.util.Functions;
 public class NodeSessionManager implements EnvelopeHandler {
   private static final int SESSION_CLEANUP_DELAY_SECONDS = 180;
   private static final int REQUEST_CLEANUP_DELAY_SECONDS = 60;
-  private static final Logger logger = LogManager.getLogger(NodeSessionManager.class);
+  private static final Logger LOG = LogManager.getLogger(NodeSessionManager.class);
   private final LocalNodeRecordStore localNodeRecordStore;
   private final SecretKey staticNodeKey;
   private final KBuckets nodeBucketStorage;
@@ -74,12 +74,12 @@ public class NodeSessionManager implements EnvelopeHandler {
     if (envelope.contains(Field.SESSION)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         "Envelope {} in NodeIdToSession, requirements are satisfied!", envelope.getIdString());
 
     SessionLookup sessionRequest = envelope.get(Field.SESSION_LOOKUP);
     envelope.remove(Field.SESSION_LOOKUP);
-    logger.trace(
+    LOG.trace(
         "Envelope {}: Session lookup requested for nodeId {}",
         envelope.getIdString(),
         sessionRequest);
@@ -88,11 +88,11 @@ public class NodeSessionManager implements EnvelopeHandler {
         .ifPresentOrElse(
             nodeSession -> {
               envelope.put(Field.SESSION, nodeSession);
-              logger.trace(
+              LOG.trace(
                   "Session resolved: {} in envelope #{}", nodeSession, envelope.getIdString());
             },
             () ->
-                logger.trace(
+                LOG.trace(
                     "Session could not be resolved or created for {}", sessionRequest.getNodeId()));
   }
 

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
@@ -16,14 +16,14 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
  * Field#SESSION_LOOKUP}
  */
 public class NodeSessionRequestHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(NodeSessionRequestHandler.class);
+  private static final Logger LOG = LogManager.getLogger(NodeSessionRequestHandler.class);
 
   @Override
   public void handle(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.NODE, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in NodeSessionRequestHandler, requirements are satisfied!",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
@@ -19,7 +19,7 @@ import reactor.core.publisher.FluxSink;
  * is linked with discovery client.
  */
 public class OutgoingParcelHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(OutgoingParcelHandler.class);
+  private static final Logger LOG = LogManager.getLogger(OutgoingParcelHandler.class);
 
   private final FluxSink<NetworkParcel> outgoingSink;
 
@@ -32,7 +32,7 @@ public class OutgoingParcelHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.INCOMING, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in OutgoingParcelHandler, requirements are satisfied!",
@@ -41,7 +41,7 @@ public class OutgoingParcelHandler implements EnvelopeHandler {
     if (envelope.get(Field.INCOMING) instanceof NetworkParcel) {
       NetworkParcel parcel = (NetworkParcel) envelope.get(Field.INCOMING);
       if (parcel.getPacket().getBytes().size() > IncomingDataPacker.MAX_PACKET_SIZE) {
-        logger.error(() -> "Outgoing packet is too large, dropping it: " + parcel.getPacket());
+        LOG.error(() -> "Outgoing packet is too large, dropping it: " + parcel.getPacket());
       } else {
         outgoingSink.next(parcel);
         envelope.remove(Field.INCOMING);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
@@ -21,7 +21,7 @@ import org.ethereum.beacon.discovery.util.Utils;
 /** Matches the current session state and inbound packet */
 public class PacketDispatcherHandler implements EnvelopeHandler {
 
-  private static final Logger logger = LogManager.getLogger(PacketDispatcherHandler.class);
+  private static final Logger LOG = LogManager.getLogger(PacketDispatcherHandler.class);
 
   @Override
   public void handle(Envelope envelope) {
@@ -31,7 +31,7 @@ public class PacketDispatcherHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.PACKET, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in UnknownPacketTypeByStatus, requirements are satisfied!",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
@@ -24,7 +24,7 @@ import org.ethereum.beacon.discovery.util.Functions;
 
 public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
 
-  private static final Logger logger = LogManager.getLogger(UnauthorizedMessagePacketHandler.class);
+  private static final Logger LOG = LogManager.getLogger(UnauthorizedMessagePacketHandler.class);
 
   @Override
   public void handle(Envelope envelope) {
@@ -34,7 +34,7 @@ public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in NotExpectedIncomingPacketHandler, requirements are satisfied!",
@@ -61,7 +61,7 @@ public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               unknownPacket, session.getNodeRecord(), session.getState());
-      logger.debug(error, ex);
+      LOG.debug(error, ex);
       envelope.put(Field.BAD_PACKET, unknownPacket);
       envelope.put(Field.BAD_EXCEPTION, ex);
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
@@ -21,7 +21,7 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
  * resolved by another handler.
  */
 public class UnknownPacketTagToSender implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(UnknownPacketTagToSender.class);
+  private static final Logger LOG = LogManager.getLogger(UnknownPacketTagToSender.class);
 
   @Override
   public void handle(Envelope envelope) {
@@ -32,7 +32,7 @@ public class UnknownPacketTagToSender implements EnvelopeHandler {
       return;
     }
 
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in UnknownPacketTagToSender, requirements are satisfied!",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -32,7 +32,7 @@ import org.ethereum.beacon.discovery.util.Functions;
 
 /** Handles {@link WhoAreYouPacket} in {@link Field#PACKET_WHOAREYOU} field */
 public class WhoAreYouPacketHandler implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(WhoAreYouPacketHandler.class);
+  private static final Logger LOG = LogManager.getLogger(WhoAreYouPacketHandler.class);
 
   private final Pipeline outgoingPipeline;
   private final Scheduler scheduler;
@@ -50,7 +50,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
     if (!HandlerUtil.requireField(Field.PACKET_WHOAREYOU, envelope)) {
       return;
     }
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in WhoAreYouPacketHandler, requirements are satisfied!",
@@ -65,7 +65,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
       boolean nonceMatches =
           session.getLastOutboundNonce().map(whoAreYouNonce::equals).orElse(false);
       if (!nonceMatches) {
-        logger.debug(
+        LOG.debug(
             "Verification not passed for message [{}] from node {} in status {}",
             whoAreYouPacket,
             nodeRecord,
@@ -96,7 +96,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
 
       Bytes32 destNodeId = Bytes32.wrap(nodeRecord.getNodeId());
       Functions.HKDFKeys hkdfKeys =
-          Functions.hkdf_expand(
+          Functions.hkdfExpand(
               session.getHomeNodeId(),
               destNodeId,
               ephemeralKeyPair.secretKey(),
@@ -148,7 +148,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               whoAreYouPacket, session.getNodeRecord(), session.getState());
-      logger.debug(error, ex);
+      LOG.debug(error, ex);
       envelope.remove(Field.PACKET_WHOAREYOU);
       session.cancelAllRequests("Bad WHOAREYOU received from node");
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouSessionResolver.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouSessionResolver.java
@@ -20,7 +20,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
  * Field#PACKET_WHOAREYOU}
  */
 public class WhoAreYouSessionResolver implements EnvelopeHandler {
-  private static final Logger logger = LogManager.getLogger(WhoAreYouSessionResolver.class);
+  private static final Logger LOG = LogManager.getLogger(WhoAreYouSessionResolver.class);
   private final NodeSessionManager nodeSessionManager;
 
   public WhoAreYouSessionResolver(NodeSessionManager nodeSessionManager) {
@@ -37,7 +37,7 @@ public class WhoAreYouSessionResolver implements EnvelopeHandler {
       return;
     }
 
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Envelope %s in WhoAreYouSessionResolver, requirements are satisfied!",
@@ -53,7 +53,7 @@ public class WhoAreYouSessionResolver implements EnvelopeHandler {
           envelope.put(Field.SESSION, session);
         },
         () -> {
-          logger.trace("Unexpected WHOAREYOU packet: no source nonce found");
+          LOG.trace("Unexpected WHOAREYOU packet: no source nonce found");
           envelope.put(Field.BAD_PACKET, packet);
           envelope.put(Field.BAD_EXCEPTION, new RuntimeException("Not expected WHOAREYOU packet"));
         });

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -14,7 +14,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.util.Functions;
 
 public class FindNodeResponseHandler implements MultiPacketResponseHandler<NodesMessage> {
-  private static final Logger logger = LogManager.getLogger(FindNodeResponseHandler.class);
+  private static final Logger LOG = LogManager.getLogger(FindNodeResponseHandler.class);
   private static final int NOT_SET = -1;
   private static final int MAX_TOTAL_PACKETS = 16;
   private final List<NodeRecord> foundNodes = new ArrayList<>();
@@ -45,7 +45,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
     receivedPackets++;
 
     // Parse node records
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Received %s node records in session %s. Packet %s/%s.",
@@ -68,7 +68,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
 
   private boolean isValid(final NodeRecord record) {
     if (!record.isValid()) {
-      logger.debug("Rejecting invalid node record {}", record);
+      LOG.debug("Rejecting invalid node record {}", record);
       return false;
     }
     return true;
@@ -77,7 +77,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
   private boolean hasCorrectDistance(final NodeSession session, final NodeRecord nodeRecordV5) {
     final int actualDistance = Functions.logDistance(nodeRecordV5.getNodeId(), session.getNodeId());
     if (!distances.contains(actualDistance)) {
-      logger.debug(
+      LOG.debug(
           "Rejecting node record {} received from {} because distance was not in {}.",
           nodeRecordV5.getNodeId(),
           session.getNodeId(),

--- a/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/processor/DiscoveryV5MessageProcessor.java
@@ -31,7 +31,7 @@ import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
  * of v5 message to handle appropriate message.
  */
 public class DiscoveryV5MessageProcessor implements DiscoveryMessageProcessor<V5Message> {
-  private static final Logger logger = LogManager.getLogger(DiscoveryV5MessageProcessor.class);
+  private static final Logger LOG = LogManager.getLogger(DiscoveryV5MessageProcessor.class);
 
   @SuppressWarnings({"rawtypes"})
   private final Map<MessageCode, MessageHandler> messageHandlers = new HashMap<>();
@@ -62,7 +62,7 @@ public class DiscoveryV5MessageProcessor implements DiscoveryMessageProcessor<V5
   public void handleMessage(V5Message message, NodeSession session) {
     MessageCode code = message.getCode();
     MessageHandler messageHandler = messageHandlers.get(code);
-    logger.trace(() -> String.format("Handling message %s in session %s", message, session));
+    LOG.trace(() -> String.format("Handling message %s in session %s", message, session));
     if (messageHandler == null) {
       throw new RuntimeException("Not implemented yet");
     }

--- a/src/main/java/org/ethereum/beacon/discovery/processor/MessageProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/processor/MessageProcessor.java
@@ -18,7 +18,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
  * DiscoveryMessageDecoder}'s.
  */
 public class MessageProcessor {
-  private static final Logger logger = LogManager.getLogger(MessageProcessor.class);
+  private static final Logger LOG = LogManager.getLogger(MessageProcessor.class);
 
   @SuppressWarnings({"rawtypes"})
   private final Map<DiscoveryProtocol, DiscoveryMessageProcessor> messageProcessors =
@@ -40,7 +40,7 @@ public class MessageProcessor {
           String.format(
               "Message %s with identity %s received in session %s is not supported",
               message, protocol, session);
-      logger.debug(error);
+      LOG.debug(error);
       throw new RuntimeException(error);
     }
     messageHandler.handleMessage(message, session);

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/DefaultSchedulers.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/DefaultSchedulers.java
@@ -14,9 +14,9 @@ import org.apache.logging.log4j.Logger;
 
 public class DefaultSchedulers extends AbstractSchedulers {
 
-  private static final Logger logger = LogManager.getLogger(DefaultSchedulers.class);
+  private static final Logger LOG = LogManager.getLogger(DefaultSchedulers.class);
 
-  private Consumer<Throwable> errorHandler = t -> logger.error("Unhandled exception:", t);
+  private Consumer<Throwable> errorHandler = t -> LOG.error("Unhandled exception:", t);
   private volatile boolean started;
 
   public void setErrorHandler(Consumer<Throwable> errorHandler) {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/DiscoveryProtocol.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/DiscoveryProtocol.java
@@ -12,11 +12,11 @@ public enum DiscoveryProtocol {
   V4("v4"),
   V5("v5");
 
-  private static final Map<String, DiscoveryProtocol> nameMap = new HashMap<>();
+  private static final Map<String, DiscoveryProtocol> NAME_MAP = new HashMap<>();
 
   static {
     for (DiscoveryProtocol scheme : DiscoveryProtocol.values()) {
-      nameMap.put(scheme.name, scheme);
+      NAME_MAP.put(scheme.name, scheme);
     }
   }
 
@@ -27,7 +27,7 @@ public enum DiscoveryProtocol {
   }
 
   public static DiscoveryProtocol fromString(String name) {
-    return nameMap.get(name);
+    return NAME_MAP.get(name);
   }
 
   public String stringName() {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchema.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchema.java
@@ -11,11 +11,11 @@ import java.util.Map;
 public enum IdentitySchema {
   V4("v4");
 
-  private static final Map<String, IdentitySchema> nameMap = new HashMap<>();
+  private static final Map<String, IdentitySchema> NAME_MAP = new HashMap<>();
 
   static {
     for (IdentitySchema scheme : IdentitySchema.values()) {
-      nameMap.put(scheme.name, scheme);
+      NAME_MAP.put(scheme.name, scheme);
     }
   }
 
@@ -26,7 +26,7 @@ public enum IdentitySchema {
   }
 
   public static IdentitySchema fromString(String name) {
-    return nameMap.get(name);
+    return NAME_MAP.get(name);
   }
 
   public String stringName() {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
@@ -29,7 +29,7 @@ import org.ethereum.beacon.discovery.util.Functions;
 import org.ethereum.beacon.discovery.util.Utils;
 
 public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
-  private static final Logger logger = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private final LoadingCache<Bytes, Bytes> nodeIdCache =
       CacheBuilder.newBuilder()
@@ -45,7 +45,7 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
       return false;
     }
     if (nodeRecord.get(EnrField.PKEY_SECP256K1) == null) {
-      logger.trace(
+      LOG.trace(
           "Field {} does not exist but required for scheme {}",
           EnrField.PKEY_SECP256K1,
           getScheme());
@@ -140,7 +140,7 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
     try {
       return Optional.of(new InetSocketAddress(getInetAddress(ipBytes), port));
     } catch (final UnknownHostException e) {
-      logger.trace("Unable to resolve host: {}", ipBytes);
+      LOG.trace("Unable to resolve host: {}", ipBytes);
       return Optional.empty();
     }
   }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentityScheme.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentityScheme.java
@@ -12,11 +12,11 @@ public enum IdentityScheme {
   V4("v4"),
   V5("v5");
 
-  private static final Map<String, IdentityScheme> nameMap = new HashMap<>();
+  private static final Map<String, IdentityScheme> NAME_MAP = new HashMap<>();
 
   static {
     for (IdentityScheme scheme : IdentityScheme.values()) {
-      nameMap.put(scheme.name, scheme);
+      NAME_MAP.put(scheme.name, scheme);
     }
   }
 
@@ -27,7 +27,7 @@ public enum IdentityScheme {
   }
 
   public static IdentityScheme fromString(String name) {
-    return nameMap.get(name);
+    return NAME_MAP.get(name);
   }
 
   public String stringName() {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeRecord.java
@@ -38,7 +38,7 @@ public class NodeRecord {
    */
   public static final int MAX_ENCODED_SIZE = 300;
 
-  private static final EnrFieldInterpreter enrFieldInterpreter = EnrFieldInterpreterV4.DEFAULT;
+  private static final EnrFieldInterpreter ENR_FIELD_INTERPRETER = EnrFieldInterpreterV4.DEFAULT;
   private final UInt64 seq;
   // Signature
   private Bytes signature;
@@ -74,7 +74,8 @@ public class NodeRecord {
       Bytes signature,
       Map<String, Object> rawFields) {
     NodeRecord nodeRecord = new NodeRecord(identitySchemaInterpreter, seq, signature);
-    rawFields.forEach((key, value) -> nodeRecord.set(key, enrFieldInterpreter.decode(key, value)));
+    rawFields.forEach(
+        (key, value) -> nodeRecord.set(key, ENR_FIELD_INTERPRETER.decode(key, value)));
     return nodeRecord;
   }
 
@@ -173,7 +174,7 @@ public class NodeRecord {
               continue;
             }
             listWriter.writeString(key);
-            enrFieldInterpreter.encode(listWriter, key, fields.get(key));
+            ENR_FIELD_INTERPRETER.encode(listWriter, key, fields.get(key));
           }
         });
   }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -48,7 +48,7 @@ import org.ethereum.beacon.discovery.type.Bytes16;
  * other `node`
  */
 public class NodeSession {
-  private static final Logger logger = LogManager.getLogger(NodeSession.class);
+  private static final Logger LOG = LogManager.getLogger(NodeSession.class);
 
   public static final int REQUEST_ID_SIZE = 8;
   private final Bytes32 homeNodeId;
@@ -113,7 +113,7 @@ public class NodeSession {
   }
 
   public void sendOutgoingOrdinary(final V5Message message) {
-    logger.trace(() -> String.format("Sending outgoing message %s in session %s", message, this));
+    LOG.trace(() -> String.format("Sending outgoing message %s in session %s", message, this));
     Bytes16 maskingIV = generateMaskingIV();
     Header<OrdinaryAuthData> header =
         Header.createOrdinaryHeader(getHomeNodeId(), Bytes12.wrap(generateNonce()));
@@ -126,13 +126,13 @@ public class NodeSession {
     Header<OrdinaryAuthData> header =
         Header.createOrdinaryHeader(getHomeNodeId(), Bytes12.wrap(generateNonce()));
     OrdinaryMessagePacket packet = OrdinaryMessagePacket.createRandom(header, randomData);
-    logger.trace(
+    LOG.trace(
         () -> String.format("Sending outgoing Random message %s in session %s", packet, this));
     sendOutgoing(generateMaskingIV(), packet);
   }
 
   public void sendOutgoingWhoAreYou(final WhoAreYouPacket packet) {
-    logger.trace(
+    LOG.trace(
         () -> String.format("Sending outgoing WhoAreYou message %s in session %s", packet, this));
     Bytes16 maskingIV = generateMaskingIV();
     whoAreYouChallenge = Optional.of(Bytes.wrap(maskingIV, packet.getHeader().getBytes()));
@@ -141,7 +141,7 @@ public class NodeSession {
 
   public void sendOutgoingHandshake(
       final Header<HandshakeAuthData> header, final V5Message message) {
-    logger.trace(
+    LOG.trace(
         () ->
             String.format(
                 "Sending outgoing Handshake message %s, %s in session %s", header, message, this));
@@ -185,7 +185,7 @@ public class NodeSession {
     requestExpirationScheduler.put(
         wrappedId,
         () -> {
-          logger.trace(
+          LOG.trace(
               () ->
                   String.format(
                       "Request %s expired for id %s in session %s: no reply",
@@ -204,7 +204,7 @@ public class NodeSession {
 
   /** Updates request info. Thread-safe. */
   public synchronized void cancelAllRequests(final String message) {
-    logger.debug(() -> String.format("Cancelling all requests in session %s", this));
+    LOG.debug(() -> String.format("Cancelling all requests in session %s", this));
     Set<Bytes> requestIdsCopy = new HashSet<>(requestIdStatuses.keySet());
     requestIdsCopy.forEach(
         requestId -> {
@@ -326,7 +326,7 @@ public class NodeSession {
 
   public synchronized void onNodeRecordReceived(final NodeRecord node) {
     if (node.getNodeId().equals(nodeId) && isUpdateRequired(node, nodeRecord)) {
-      logger.trace(
+      LOG.trace(
           () ->
               String.format(
                   "NodeRecord updated from %s to %s in session %s", nodeRecord, node, this));
@@ -351,7 +351,7 @@ public class NodeSession {
   }
 
   public synchronized void setState(final SessionState newStatus) {
-    logger.trace(
+    LOG.trace(
         () -> String.format("Switching status of node %s from %s to %s", nodeId, state, newStatus));
     this.state = newStatus;
   }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeStatus.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeStatus.java
@@ -13,11 +13,11 @@ public enum NodeStatus {
   SLEEP(0x02), // Didn't answer last time(s)
   DEAD(0x03); // Didn't answer for a long time
 
-  private static final Map<Integer, NodeStatus> codeMap = new HashMap<>();
+  private static final Map<Integer, NodeStatus> CODE_MAP = new HashMap<>();
 
   static {
     for (NodeStatus type : NodeStatus.values()) {
-      codeMap.put(type.code, type);
+      CODE_MAP.put(type.code, type);
     }
   }
 
@@ -28,7 +28,7 @@ public enum NodeStatus {
   }
 
   public static NodeStatus fromNumber(int i) {
-    return codeMap.get(i);
+    return CODE_MAP.get(i);
   }
 
   public byte byteCode() {

--- a/src/main/java/org/ethereum/beacon/discovery/util/CryptoUtil.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/CryptoUtil.java
@@ -22,7 +22,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class CryptoUtil {
 
-  private static final BouncyCastleProvider securityProvider = new BouncyCastleProvider();
+  private static final BouncyCastleProvider SECURITY_PROVIDER = new BouncyCastleProvider();
 
   public static Bytes32 sha256(final Bytes indexBytes) {
     final MessageDigest sha256Digest = getSha256Digest();
@@ -33,7 +33,7 @@ public class CryptoUtil {
   @SuppressWarnings("DoNotInvokeMessageDigestDirectly")
   private static MessageDigest getSha256Digest() {
     try {
-      return MessageDigest.getInstance("sha256", securityProvider);
+      return MessageDigest.getInstance("sha256", SECURITY_PROVIDER);
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Functions.java
@@ -32,7 +32,7 @@ import org.bouncycastle.math.ec.ECPoint;
 
 /** Set of cryptography and utilities functions used in discovery */
 public class Functions {
-  private static final Logger logger = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   public static final int PRIVKEY_SIZE = 32;
   public static final int PUBKEY_SIZE = 64;
   public static final int SIGNATURE_SIZE = 64;
@@ -83,7 +83,7 @@ public class Functions {
   public static boolean verifyECDSASignature(
       final Bytes signature, final Bytes32 hashedMessage, final Bytes pubKey) {
     if (signature.size() != SIGNATURE_SIZE) {
-      logger.trace("Invalid signature size, should be {} bytes", SIGNATURE_SIZE);
+      LOG.trace("Invalid signature size, should be {} bytes", SIGNATURE_SIZE);
       return false;
     }
     final PublicKey publicKey = derivePublicKeyFromCompressed(pubKey);
@@ -102,7 +102,7 @@ public class Functions {
         }
       }
     } catch (IllegalArgumentException e) {
-      logger.trace("Failed to verify ECDSA signature", e);
+      LOG.trace("Failed to verify ECDSA signature", e);
     }
     return false;
   }
@@ -174,22 +174,22 @@ public class Functions {
    * prk = HKDF-Extract(secret, id-nonce)
    * initiator-key, recipient-key, auth-resp-key = HKDF-Expand(prk, info)</code>
    */
-  public static HKDFKeys hkdf_expand(
+  public static HKDFKeys hkdfExpand(
       final Bytes srcNodeId,
       final Bytes destNodeId,
       final SecretKey srcSecretKey,
       final Bytes destPubKey,
       final Bytes idNonce) {
     final Bytes keyAgreement = deriveECDHKeyAgreement(srcSecretKey, destPubKey);
-    return hkdf_expand(srcNodeId, destNodeId, keyAgreement, idNonce);
+    return hkdfExpand(srcNodeId, destNodeId, keyAgreement, idNonce);
   }
 
   /**
-   * {@link #hkdf_expand(Bytes, Bytes, SecretKey, Bytes, Bytes)} but with keyAgreement already
+   * {@link #hkdfExpand(Bytes, Bytes, SecretKey, Bytes, Bytes)} but with keyAgreement already
    * derived by {@link #deriveECDHKeyAgreement(SecretKey, Bytes)}
    */
   @SuppressWarnings({"DefaultCharset"})
-  public static HKDFKeys hkdf_expand(
+  public static HKDFKeys hkdfExpand(
       final Bytes srcNodeId,
       final Bytes destNodeId,
       final Bytes keyAgreement,

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryManagerTest.java
@@ -25,6 +25,7 @@ import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.Functions;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("JavaCase")
 public class DiscoveryManagerTest {
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/FunctionsTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/FunctionsTest.java
@@ -69,10 +69,10 @@ public class FunctionsTest {
     Bytes idNonce =
         Bytes.fromHexString("68b02a985ecb99cc2d10cf188879d93ae7684c4f4707770017b078c6497c5a5d");
     Functions.HKDFKeys keys1 =
-        Functions.hkdf_expand(
+        Functions.hkdfExpand(
             nodeId1, nodeId2, testKey1.secretKey(), testKey2.publicKey().bytes(), idNonce);
     Functions.HKDFKeys keys2 =
-        Functions.hkdf_expand(
+        Functions.hkdfExpand(
             nodeId1, nodeId2, testKey2.secretKey(), testKey1.publicKey().bytes(), idNonce);
     assertEquals(keys1, keys2);
   }
@@ -103,7 +103,7 @@ public class FunctionsTest {
     final Bytes idNonce =
         Bytes.fromHexString("0x0101010101010101010101010101010101010101010101010101010101010101");
 
-    final HKDFKeys hkdfKeys = Functions.hkdf_expand(nodeIdA, nodeIdB, secretKey, idNonce);
+    final HKDFKeys hkdfKeys = Functions.hkdfExpand(nodeIdA, nodeIdB, secretKey, idNonce);
     assertEquals(
         Bytes.fromHexString("0x238d8b50e4363cf603a48c6cc3542967"), hkdfKeys.getInitiatorKey());
     assertEquals(

--- a/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/NodeRecordTest.java
@@ -132,17 +132,17 @@ public class NodeRecordTest {
   public void testCustomField() {
     Random rnd = new Random(SEED);
     KeyPair keyPair = Functions.randomKeyPair(rnd);
-    final String CUSTOM_FIELD_NAME = "custom_field_name";
-    final Bytes CUSTOM_FIELD_VALUE = Bytes.fromHexString("0xdeadbeef");
+    final String customFieldName = "custom_field_name";
+    final Bytes customFieldValue = Bytes.fromHexString("0xdeadbeef");
     NodeRecord nodeRecord =
         new NodeRecordBuilder()
             .seq(0)
             .address("127.0.0.1", 30303)
             .secretKey(keyPair.secretKey())
-            .customField(CUSTOM_FIELD_NAME, CUSTOM_FIELD_VALUE)
+            .customField(customFieldName, customFieldValue)
             .build();
     assertTrue(nodeRecord.isValid());
-    assertEquals(nodeRecord.get(CUSTOM_FIELD_NAME), CUSTOM_FIELD_VALUE);
+    assertEquals(nodeRecord.get(customFieldName), customFieldValue);
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/community/CryptoTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/community/CryptoTest.java
@@ -62,7 +62,7 @@ public class CryptoTest {
     Bytes expectedInitiatorKey = Bytes.fromHexString("0x238d8b50e4363cf603a48c6cc3542967");
     Bytes expectedRecipientKey = Bytes.fromHexString("0xbebc0183484f7e7ca2ac32e3d72c8891");
     Bytes expectedAuthResponseKey = Bytes.fromHexString("0xe987ad9e414d5b4f9bfe4ff1e52f2fae");
-    Functions.HKDFKeys keys = Functions.hkdf_expand(nodeIdA, nodeIdB, secretKey, idNonce);
+    Functions.HKDFKeys keys = Functions.hkdfExpand(nodeIdA, nodeIdB, secretKey, idNonce);
     Assertions.assertEquals(expectedInitiatorKey, keys.getInitiatorKey());
     Assertions.assertEquals(expectedRecipientKey, keys.getRecipientKey());
     Assertions.assertEquals(expectedAuthResponseKey, keys.getAuthResponseKey());

--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -50,12 +50,12 @@ import org.junit.jupiter.api.Test;
 
 public class DiscoveryIntegrationTest {
 
-  private static final Logger logger = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   public static final String LOCALHOST = "127.0.0.1";
   public static final Duration RETRY_TIMEOUT = Duration.ofSeconds(30);
   public static final Duration LIVE_CHECK_INTERVAL = Duration.ofSeconds(30);
   public static final Consumer<DiscoverySystemBuilder> NO_MODIFY = __ -> {};
-  private static final AtomicInteger nextPort = new AtomicInteger(9001);
+  private static final AtomicInteger NEXT_PORT = new AtomicInteger(9001);
   private final List<DiscoverySystem> managers = new ArrayList<>();
 
   @AfterEach
@@ -99,15 +99,15 @@ public class DiscoveryIntegrationTest {
 
   @Test
   public void shouldSuccessfullyUpdateCustomFieldValue() throws Exception {
-    final String CUSTOM_FIELD_NAME = "custom_field_name";
-    final Bytes CUSTOM_FIELD_VALUE = Bytes.fromHexString("0xdeadbeef");
+    final String customFieldName = "custom_field_name";
+    final Bytes customFieldValue = Bytes.fromHexString("0xdeadbeef");
     final DiscoverySystem bootnode = createDiscoveryClient();
     assertTrue(bootnode.getLocalNodeRecord().isValid());
 
-    bootnode.updateCustomFieldValue(CUSTOM_FIELD_NAME, CUSTOM_FIELD_VALUE);
+    bootnode.updateCustomFieldValue(customFieldName, customFieldValue);
 
     assertTrue(bootnode.getLocalNodeRecord().isValid());
-    assertEquals(bootnode.getLocalNodeRecord().get(CUSTOM_FIELD_NAME), CUSTOM_FIELD_VALUE);
+    assertEquals(bootnode.getLocalNodeRecord().get(customFieldName), customFieldValue);
   }
 
   @Test
@@ -417,7 +417,7 @@ public class DiscoveryIntegrationTest {
       throws Exception {
 
     for (int i = 0; i < 10; i++) {
-      int port = nextPort.incrementAndGet();
+      int port = NEXT_PORT.incrementAndGet();
       final NodeRecordBuilder nodeRecordBuilder = new NodeRecordBuilder();
       if (signNodeRecord) {
         nodeRecordBuilder.secretKey(keyPair.secretKey());
@@ -449,7 +449,7 @@ public class DiscoveryIntegrationTest {
       } catch (final Exception e) {
         discoverySystem.stop();
         if (e.getCause() instanceof BindException) {
-          logger.info("Port conflict detected, retrying with new port", e);
+          LOG.info("Port conflict detected, retrying with new port", e);
         } else {
           throw e;
         }

--- a/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/message/handler/PingHandlerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class PingHandlerTest {
-  private final InetSocketAddress REMOTE_ADDRESS = new InetSocketAddress("localhost", 25234);
+  private static final InetSocketAddress REMOTE_ADDRESS = new InetSocketAddress("localhost", 25234);
   private final NodeSession session = mock(NodeSession.class);
   private final EnrUpdateTracker enrUpdateTracker = mock(EnrUpdateTracker.class);
   private final NodeInfo localNode = TestUtil.generateNode(9000);

--- a/src/test/java/org/ethereum/beacon/discovery/reference/CryptoTests.java
+++ b/src/test/java/org/ethereum/beacon/discovery/reference/CryptoTests.java
@@ -47,7 +47,7 @@ public class CryptoTests {
     Bytes expectedRecipientKeyBytes = Bytes.fromHexString("0xac74bb8773749920b0d3a8881c173ec5");
 
     HKDFKeys hkdfKeys =
-        Functions.hkdf_expand(
+        Functions.hkdfExpand(
             nodeIdABytes, nodeIdBBytes, LOCAL_SECRET, destPubkeyBytes, challengeDataBytes);
     assertThat(hkdfKeys.getInitiatorKey()).isEqualTo(expectedInitiatorKeyBytes);
     assertThat(hkdfKeys.getRecipientKey()).isEqualTo(expectedRecipientKeyBytes);

--- a/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
@@ -181,22 +181,22 @@ class IdentitySchemaV4InterpreterTest {
 
   @Test
   public void shouldUpdateCustomFieldValue() {
-    final String CUSTOM_FIELD_NAME = "custom_field_name";
-    final Bytes CUSTOM_FIELD_VALUE1 = Bytes.fromHexString("0xdeadbeef");
-    final Bytes CUSTOM_FIELD_VALUE2 = Bytes.fromHexString("0xbeef");
+    final String customFieldName = "custom_field_name";
+    final Bytes customFieldValue1 = Bytes.fromHexString("0xdeadbeef");
+    final Bytes customFieldValue2 = Bytes.fromHexString("0xbeef");
     final NodeRecord initialRecord =
         createNodeRecord(
             new EnrField(EnrField.IP_V4, Bytes.wrap(new byte[4])),
             new EnrField(EnrField.UDP, 3030),
-            new EnrField(CUSTOM_FIELD_NAME, CUSTOM_FIELD_VALUE1));
+            new EnrField(customFieldName, customFieldValue1));
 
-    assertThat(initialRecord.get(CUSTOM_FIELD_NAME)).isEqualTo(CUSTOM_FIELD_VALUE1);
+    assertThat(initialRecord.get(customFieldName)).isEqualTo(customFieldValue1);
 
     final NodeRecord newRecord =
         interpreter.createWithUpdatedCustomField(
-            initialRecord, CUSTOM_FIELD_NAME, CUSTOM_FIELD_VALUE2, SECRET_KEY);
+            initialRecord, customFieldName, customFieldValue2, SECRET_KEY);
 
-    assertThat(newRecord.get(CUSTOM_FIELD_NAME)).isEqualTo(CUSTOM_FIELD_VALUE2);
+    assertThat(newRecord.get(customFieldName)).isEqualTo(customFieldValue2);
   }
 
   @Test

--- a/src/test/java/org/ethereum/beacon/discovery/task/RecursiveLookupTaskTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/task/RecursiveLookupTaskTest.java
@@ -52,7 +52,7 @@ class RecursiveLookupTaskTest {
   public static final NodeRecord PEER4 = createPeer(PEER4_ID);
   public static final NodeRecord PEER5 = createPeer(PEER5_ID);
 
-  private final Bytes TARGET =
+  private static final Bytes TARGET =
       Bytes.fromHexString("0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD");
   private final KBuckets buckets = mock(KBuckets.class);
   private final FindNodesAction findNodesAction = mock(FindNodesAction.class);


### PR DESCRIPTION
## PR Description

This touches a lot of files, but the changes are pretty minor. A lot fewer findings than Teku.

* Enable the `JavaCase` errorprone check.
* Change severity from INFO to WARNING.
* Rename `logger` (they're all static final) to `LOG` (simpler than `LOGGER`).
* Rename all static final variables from camelCase to UPPER_SNAKE.
* Rename local variables from UPPER_SNAKE to camelCase (there were just a few).
* Rename `Functions.hkdf_expand` to `Functions.hkdfExpand`.
* Add `static` qualifier to a few variables that should probably have it.
* Suppress warnings for `DiscoveryManagerTest` because I think it's easier to read how it is currently.