### PR TITLE
Query distances from left/right of target distance

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
@@ -23,7 +23,7 @@ public class KBuckets {
    * Minimum distance we create a bucket for. 0 is our local node record and negative distances
    * aren't allowed.
    */
-  private static final int MIN_BUCKET = 1;
+  public static final int MINIMUM_BUCKET = 1;
 
   /** Maximum distance we create a bucket for. This is enough to cover all 32 byte node IDs. */
   public static final int MAXIMUM_BUCKET = 256;
@@ -130,7 +130,7 @@ public class KBuckets {
   }
 
   private Optional<KBucket> getOrCreateBucket(final int distance) {
-    if (distance > MAXIMUM_BUCKET || distance < MIN_BUCKET) {
+    if (distance > MAXIMUM_BUCKET || distance < MINIMUM_BUCKET) {
       // Distance too great, ignore.
       return Optional.empty();
     }

--- a/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManager.java
@@ -116,7 +116,8 @@ public class DiscoveryTaskManager {
         distances.add(right);
       }
 
-      // If NUM_DISTANCES_TO_QUERY is an even number, this check is necessary.
+      // This check is necessary if NUM_DISTANCES_TO_QUERY is an even number or the target distance
+      // is close to the minimum/maximum boundary.
       if (distances.size() == NUM_DISTANCES_TO_QUERY) {
         break;
       }

--- a/src/test/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManagerTest.java
@@ -1,0 +1,49 @@
+package org.ethereum.beacon.discovery.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.ethereum.beacon.discovery.storage.KBuckets;
+import org.junit.jupiter.api.Test;
+
+public class DiscoveryTaskManagerTest {
+
+  @Test
+  void getClosestDistanceShouldReturnThree() {
+    for (int distance = KBuckets.MINIMUM_BUCKET; distance <= KBuckets.MAXIMUM_BUCKET; distance++) {
+      assertThat(DiscoveryTaskManager.getClosestDistances(distance)).hasSize(3);
+    }
+  }
+
+  @Test
+  void getClosestDistanceShouldRejectTargetBelowMin() {
+    assertThatThrownBy(() -> DiscoveryTaskManager.getClosestDistances(KBuckets.MINIMUM_BUCKET - 1))
+        .hasMessageContaining("invalid target distance")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void getClosestDistanceShouldRejectTargetAboveMax() {
+    assertThatThrownBy(() -> DiscoveryTaskManager.getClosestDistances(KBuckets.MAXIMUM_BUCKET + 1))
+        .hasMessageContaining("invalid target distance")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void getClosestDistanceMiddleTarget() {
+    assertThat(DiscoveryTaskManager.getClosestDistances(128)).isEqualTo(List.of(128, 129, 127));
+  }
+
+  @Test
+  void getClosestDistanceMinTarget() {
+    assertThat(DiscoveryTaskManager.getClosestDistances(KBuckets.MINIMUM_BUCKET))
+        .isEqualTo(List.of(1, 2, 3));
+  }
+
+  @Test
+  void getClosestDistanceMaxTarget() {
+    assertThat(DiscoveryTaskManager.getClosestDistances(KBuckets.MAXIMUM_BUCKET))
+        .isEqualTo(List.of(256, 255, 254));
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/task/DiscoveryTaskManagerTest.java
@@ -1,3 +1,6 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.ethereum.beacon.discovery.task;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## PR Description

So the [lookup section of the spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#lookup) isn't super clear in this regard, but I think `findNodes` isn't querying the ideal distances. Given a target distance of 10, it will query 10, 11, and 12. I think it should query 9, 10, 11. 9 is closer to 10 than 12. Slight distinction but it may help. Also, while I don't think it's common, the previous implementation doesn't work very well with a target distance of 255 and 256; it will only query one or two distances, instead of the typical three. Thoughts?