### PR TITLE
Use modern docker image when building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   medium_executor:
     docker:
-      - image: circleci/openjdk:11.0.4-jdk-stretch
+      - image: cimg/openjdk:11.0.13
     resource_class: medium
     working_directory: ~/project
     environment:


### PR DESCRIPTION
## PR Description
Updates the docker image used when building as the old image was deprecated.