### PR TITLE
Use Guava cache for ExpirationSet to simplify and optimise implementation

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBucket.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.liveness.LivenessChecker;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
@@ -41,15 +42,20 @@ class KBucket {
     this.clock = clock;
   }
 
+  public void updateStats(final int distance, final BucketStats stats) {
+    stats.setBucketStat(distance, (int) streamLiveEntries().count(), nodes.size());
+  }
+
   public List<NodeRecord> getAllNodes() {
     return nodes.stream().map(BucketEntry::getNode).collect(Collectors.toList());
   }
 
   public List<NodeRecord> getLiveNodes() {
-    return nodes.stream()
-        .takeWhile(BucketEntry::isLive)
-        .map(BucketEntry::getNode)
-        .collect(Collectors.toList());
+    return streamLiveEntries().map(BucketEntry::getNode).collect(Collectors.toList());
+  }
+
+  private Stream<BucketEntry> streamLiveEntries() {
+    return nodes.stream().takeWhile(BucketEntry::isLive);
   }
 
   public Optional<NodeRecord> getPendingNode() {

--- a/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/KBuckets.java
@@ -102,10 +102,7 @@ public class KBuckets {
 
   public synchronized BucketStats getStats() {
     final BucketStats stats = new BucketStats();
-    buckets.forEach(
-        (distance, bucket) ->
-            stats.setBucketStat(
-                distance, bucket.getLiveNodes().size(), bucket.getAllNodes().size()));
+    buckets.forEach((distance, bucket) -> bucket.updateStats(distance, stats));
     return stats;
   }
 

--- a/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/database/ExpirationSetTest.java
@@ -15,44 +15,52 @@ public class ExpirationSetTest {
   private final Clock clock = mock(Clock.class);
 
   @Test
-  public void shouldAppreciateSize() {
-    when(clock.millis()).thenReturn(12345L);
+  public void shouldNotExceedMaximumSize() {
+    when(clock.millis()).thenReturn(45L);
     ExpirationSet<String> expirationSet = new ExpirationSet<>(1, clock, 3);
     expirationSet.add("a");
     expirationSet.add("b");
     expirationSet.add("c");
     expirationSet.add("d");
-    assertThat(expirationSet.size()).isEqualTo(3);
-    assertThat(expirationSet.contains("d")).isTrue();
-  }
-
-  @Test
-  public void oldElementsShouldExpire() {
-    when(clock.millis()).thenReturn(12345L);
-    ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
-    expirationSet.add("a");
-    expirationSet.add("b");
-    assertThat(expirationSet.size()).isEqualTo(2);
-    when(clock.millis()).thenReturn(12352L);
-    expirationSet.add("c");
-    assertThat(expirationSet.size()).isEqualTo(1);
-    when(clock.millis()).thenReturn(12355L);
-    expirationSet.add("d");
-    assertThat(expirationSet.size()).isEqualTo(2);
+    assertThat(expirationSet.contains("a")).isFalse();
+    assertThat(expirationSet.contains("b")).isTrue();
     assertThat(expirationSet.contains("c")).isTrue();
     assertThat(expirationSet.contains("d")).isTrue();
   }
 
   @Test
-  public void addingExistingElementShouldBeIgnored() {
-    when(clock.millis()).thenReturn(12345L);
+  public void shouldExpireOldElements() {
+    when(clock.millis()).thenReturn(45L);
     ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
     expirationSet.add("a");
-    when(clock.millis()).thenReturn(12349L);
+    expirationSet.add("b");
+    assertThat(expirationSet.contains("a")).isTrue();
+    assertThat(expirationSet.contains("b")).isTrue();
+    assertThat(expirationSet.contains("c")).isFalse();
+    assertThat(expirationSet.contains("d")).isFalse();
+    when(clock.millis()).thenReturn(52L);
+    expirationSet.add("c");
+    assertThat(expirationSet.contains("a")).isFalse();
+    assertThat(expirationSet.contains("b")).isFalse();
+    assertThat(expirationSet.contains("c")).isTrue();
+    assertThat(expirationSet.contains("d")).isFalse();
+    when(clock.millis()).thenReturn(55L);
+    expirationSet.add("d");
+    assertThat(expirationSet.contains("a")).isFalse();
+    assertThat(expirationSet.contains("b")).isFalse();
+    assertThat(expirationSet.contains("c")).isTrue();
+    assertThat(expirationSet.contains("d")).isTrue();
+  }
+
+  @Test
+  public void shouldIgnoreReaddedElements() {
+    when(clock.millis()).thenReturn(45L);
+    ExpirationSet<String> expirationSet = new ExpirationSet<>(5, clock, 3);
     expirationSet.add("a");
-    assertThat(expirationSet.size()).isEqualTo(1);
-    when(clock.millis()).thenReturn(12351L);
-    assertThat(expirationSet.size()).isEqualTo(0);
+    when(clock.millis()).thenReturn(49L);
+    expirationSet.add("a");
+    assertThat(expirationSet.contains("a")).isTrue();
+    when(clock.millis()).thenReturn(51L);
     assertThat(expirationSet.contains("a")).isFalse();
   }
 }


### PR DESCRIPTION
## PR Description
Simplify and optimise `ExpirationSet` by using guava cache. Fixes a bug where the newest item was removed when the set was full rather than the oldest.
Optimise stats collection in KBucket to avoid creating new lists of all nodes.

## Fixed Issue(s)
https://github.com/ConsenSys/teku/issues/6371
