### PR TITLE
Fix potential memory leak in tracking of session nonces

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -123,6 +123,9 @@ public class NodeSessionManager implements EnvelopeHandler {
   private void deleteSession(final SessionKey sessionKey) {
     NodeSession removedSession = recentSessions.remove(sessionKey);
     if (removedSession != null) {
+      // Mark inactive to prevent registering any new nonces
+      removedSession.markInactive();
+      // And then clean up the last recorded nonce, if any
       removedSession.getLastOutboundNonce().ifPresent(lastNonceToSession::remove);
     }
   }


### PR DESCRIPTION
## PR Description
Fix a couple of potential memory leaks when tracking the latest nonce for sessions.

1. A race condition could mean that a previous nonce generation hadn't yet been registered with `NodeSessionManager` before a second generation tried to replace it. This would result in both nonces being tracked with the older one never being removed and retaining a reference to the `NodeSession` permanently.
2. A `NodeSession` may be removed from `NodeSessionManager` while still in use for processing a packet which then causes it to generate a new nonce. The new nonce would be added to `NodeSessionManager` after it cleaned up the "last nonce" and would wind up being tracked after the `NodeSession` had expired leading to a memory leak.
