### PR TITLE
Implement source address filtering

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/AddressAccessPolicy.java
+++ b/src/main/java/org/ethereum/beacon/discovery/AddressAccessPolicy.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery;
+
+import java.net.InetSocketAddress;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+
+@FunctionalInterface
+public interface AddressAccessPolicy {
+  AddressAccessPolicy ALLOW_ALL = __ -> true;
+
+  boolean allow(InetSocketAddress address);
+
+  default boolean allow(NodeRecord record) {
+    return record.getTcpAddress().map(this::allow).orElse(true);
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -58,6 +58,7 @@ public class DiscoverySystemBuilder {
   private TalkHandler talkHandler = TalkHandler.NOOP;
   private NettyDiscoveryServer discoveryServer = null;
   private ExternalAddressSelector externalAddressSelector = null;
+  private AddressAccessPolicy addressAccessPolicy = AddressAccessPolicy.ALLOW_ALL;
   private final Clock clock = Clock.systemUTC();
   private final LivenessChecker livenessChecker = new LivenessChecker(clock);
 
@@ -148,6 +149,11 @@ public class DiscoverySystemBuilder {
   public DiscoverySystemBuilder externalAddressSelector(
       final ExternalAddressSelector externalAddressSelector) {
     this.externalAddressSelector = externalAddressSelector;
+    return this;
+  }
+
+  public DiscoverySystemBuilder addressAccessPolicy(final AddressAccessPolicy addressAccessPolicy) {
+    this.addressAccessPolicy = addressAccessPolicy;
     return this;
   }
 
@@ -247,7 +253,8 @@ public class DiscoverySystemBuilder {
         schedulers.newSingleThreadDaemon("discovery-client-" + clientNumber),
         expirationSchedulerFactory,
         talkHandler,
-        externalAddressSelector);
+        externalAddressSelector,
+        addressAccessPolicy);
   }
 
   /**

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.pipeline.handler;
+
+import java.net.InetSocketAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.discovery.AddressAccessPolicy;
+import org.ethereum.beacon.discovery.pipeline.Envelope;
+import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
+import org.ethereum.beacon.discovery.pipeline.Field;
+import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
+
+public class PacketSourceFilter implements EnvelopeHandler {
+  private static final Logger LOG = LogManager.getLogger(PacketSourceFilter.class);
+
+  private final AddressAccessPolicy addressAccessPolicy;
+
+  public PacketSourceFilter(final AddressAccessPolicy addressAccessPolicy) {
+    this.addressAccessPolicy = addressAccessPolicy;
+  }
+
+  @Override
+  public void handle(final Envelope envelope) {
+    if (!HandlerUtil.requireField(Field.REMOTE_SENDER, envelope)) {
+      return;
+    }
+    final InetSocketAddress sender = envelope.get(Field.REMOTE_SENDER);
+    if (!addressAccessPolicy.allow(sender)) {
+      envelope.remove(Field.INCOMING);
+      LOG.debug("Ignoring message from disallowed source {}", sender);
+    }
+  }
+}

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.discovery.AddressAccessPolicy;
 import org.ethereum.beacon.discovery.message.NodesMessage;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeSession;
@@ -19,11 +20,14 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
   private static final int MAX_TOTAL_PACKETS = 16;
   private final List<NodeRecord> foundNodes = new ArrayList<>();
   private final Collection<Integer> distances;
+  private final AddressAccessPolicy addressAccessPolicy;
   private int totalPackets = NOT_SET;
   private int receivedPackets = 0;
 
-  public FindNodeResponseHandler(final Collection<Integer> distances) {
+  public FindNodeResponseHandler(
+      final Collection<Integer> distances, final AddressAccessPolicy addressAccessPolicy) {
     this.distances = distances;
+    this.addressAccessPolicy = addressAccessPolicy;
   }
 
   @Override
@@ -53,6 +57,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
     message.getNodeRecords().stream()
         .filter(this::isValid)
         .filter(record -> hasCorrectDistance(session, record))
+        .filter(addressAccessPolicy::allow)
         .forEach(
             nodeRecord -> {
               foundNodes.add(nodeRecord);

--- a/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/DiscoveryNetworkTest.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ethereum.beacon.discovery.AddressAccessPolicy.ALLOW_ALL;
 import static org.ethereum.beacon.discovery.TestUtil.NODE_RECORD_FACTORY_NO_VERIFICATION;
 import static org.ethereum.beacon.discovery.TestUtil.TEST_TRAFFIC_READ_LIMIT;
 import static org.ethereum.beacon.discovery.TestUtil.waitFor;
@@ -80,7 +81,8 @@ public class DiscoveryNetworkTest {
             Schedulers.createDefault().newSingleThreadDaemon("tasks-1"),
             expirationSchedulerFactory,
             TalkHandler.NOOP,
-            ExternalAddressSelector.NOOP);
+            ExternalAddressSelector.NOOP,
+            ALLOW_ALL);
     livenessChecker1.setPinger(discoveryManager1::ping);
     DiscoveryManagerImpl discoveryManager2 =
         new DiscoveryManagerImpl(
@@ -97,7 +99,8 @@ public class DiscoveryNetworkTest {
             Schedulers.createDefault().newSingleThreadDaemon("tasks-2"),
             expirationSchedulerFactory,
             TalkHandler.NOOP,
-            ExternalAddressSelector.NOOP);
+            ExternalAddressSelector.NOOP,
+            ALLOW_ALL);
     livenessChecker2.setPinger(discoveryManager2::ping);
 
     // 3) Expect standard 1 => 2 dialog

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -5,6 +5,7 @@
 package org.ethereum.beacon.discovery;
 
 import static java.util.Collections.singletonList;
+import static org.ethereum.beacon.discovery.AddressAccessPolicy.ALLOW_ALL;
 import static org.ethereum.beacon.discovery.TestUtil.NODE_RECORD_FACTORY_NO_VERIFICATION;
 import static org.ethereum.beacon.discovery.pipeline.Field.BAD_PACKET;
 import static org.ethereum.beacon.discovery.pipeline.Field.MASKING_IV;
@@ -168,7 +169,7 @@ public class HandshakeHandlersTest {
         new Request<>(
             new CompletableFuture<>(),
             id -> new FindNodeMessage(id, singletonList(1)),
-            new FindNodeResponseHandler(singletonList(1)));
+            new FindNodeResponseHandler(singletonList(1), ALLOW_ALL));
     nodeSessionAt1For2.createNextRequest(request);
 
     RawPacket whoAreYouRawPacket = outgoing2Packets.poll(1, TimeUnit.SECONDS);
@@ -181,7 +182,8 @@ public class HandshakeHandlersTest {
             outgoingPipeline,
             taskScheduler,
             NODE_RECORD_FACTORY_NO_VERIFICATION,
-            mock(NodeSessionManager.class));
+            mock(NodeSessionManager.class),
+            ALLOW_ALL);
     Envelope envelopeAt2From1 = new Envelope();
     RawPacket handshakeRawPacket = outgoing1Packets.poll(1, TimeUnit.SECONDS);
     envelopeAt2From1.put(

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.pipeline.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.AddressAccessPolicy;
+import org.ethereum.beacon.discovery.network.NetworkParcel;
+import org.ethereum.beacon.discovery.network.NetworkParcelV5;
+import org.ethereum.beacon.discovery.packet.impl.RawPacketImpl;
+import org.ethereum.beacon.discovery.pipeline.Envelope;
+import org.ethereum.beacon.discovery.pipeline.Field;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.FluxSink;
+
+class OutgoingParcelHandlerTest {
+
+  public static final RawPacketImpl PACKET =
+      new RawPacketImpl(Bytes.fromHexString("0x12341234123412341234123412341234"));
+  private static final InetSocketAddress DISALLOWED_ADDRESS =
+      new InetSocketAddress(InetAddress.getLoopbackAddress(), 12345);
+  private static final InetSocketAddress ALLOWED_ADDRESS =
+      new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080);
+
+  @SuppressWarnings("unchecked")
+  private final FluxSink<NetworkParcel> outgoingSink =
+      (FluxSink<NetworkParcel>) mock(FluxSink.class);
+
+  private final AddressAccessPolicy addressAccessPolicy =
+      address -> !address.equals(DISALLOWED_ADDRESS);
+
+  private final OutgoingParcelHandler handler =
+      new OutgoingParcelHandler(outgoingSink, addressAccessPolicy);
+
+  @Test
+  void shouldNotSendPacketsToDisallowedHosts() {
+    final Envelope envelope = new Envelope();
+    envelope.put(Field.INCOMING, new NetworkParcelV5(PACKET, DISALLOWED_ADDRESS));
+    handler.handle(envelope);
+
+    verifyNoInteractions(outgoingSink);
+  }
+
+  @Test
+  void shouldSendPacketsToAllowedHosts() {
+    final Envelope envelope = new Envelope();
+    final NetworkParcelV5 parcel = new NetworkParcelV5(PACKET, ALLOWED_ADDRESS);
+    envelope.put(Field.INCOMING, parcel);
+    handler.handle(envelope);
+
+    verify(outgoingSink).next(parcel);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilterTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.pipeline.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.AddressAccessPolicy;
+import org.ethereum.beacon.discovery.pipeline.Envelope;
+import org.ethereum.beacon.discovery.pipeline.Field;
+import org.junit.jupiter.api.Test;
+
+class PacketSourceFilterTest {
+
+  private static final InetSocketAddress DISALLOWED_ADDRESS =
+      new InetSocketAddress(InetAddress.getLoopbackAddress(), 12345);
+  private static final InetSocketAddress ALLOWED_ADDRESS =
+      new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080);
+
+  private final AddressAccessPolicy addressAccessPolicy =
+      address -> !address.equals(DISALLOWED_ADDRESS);
+
+  private final PacketSourceFilter filter = new PacketSourceFilter(addressAccessPolicy);
+
+  @Test
+  void shouldAllowPacketsWhenSourceAllowed() {
+    final Envelope envelope = new Envelope();
+    final Bytes incoming = Bytes.fromHexString("0x1234");
+    envelope.put(Field.INCOMING, incoming);
+    envelope.put(Field.REMOTE_SENDER, ALLOWED_ADDRESS);
+    filter.handle(envelope);
+
+    assertThat(envelope.get(Field.INCOMING)).isEqualTo(incoming);
+  }
+
+  @Test
+  void shouldDropPacketsWhenSourceDisallowed() {
+    final Envelope envelope = new Envelope();
+    final Bytes incoming = Bytes.fromHexString("0x1234");
+    envelope.put(Field.INCOMING, incoming);
+    envelope.put(Field.REMOTE_SENDER, DISALLOWED_ADDRESS);
+    filter.handle(envelope);
+
+    assertThat(envelope.get(Field.INCOMING)).isNull();
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandlerTest.java
@@ -7,6 +7,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ethereum.beacon.discovery.AddressAccessPolicy.ALLOW_ALL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.AddressAccessPolicy;
 import org.ethereum.beacon.discovery.TestUtil;
 import org.ethereum.beacon.discovery.TestUtil.NodeInfo;
 import org.ethereum.beacon.discovery.message.NodesMessage;
@@ -27,8 +29,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class FindNodeResponseHandlerTest {
+
   private static final Bytes PEER_ID = Bytes.fromHexString("0x1234567890ABCDEF");
   private static final Bytes REQUEST_ID = Bytes.fromHexString("0x1234");
+  public static final AddressAccessPolicy DISALLOW_ALL = record -> false;
   private final NodeSession session = mock(NodeSession.class);
 
   @BeforeEach
@@ -40,7 +44,8 @@ class FindNodeResponseHandlerTest {
   public void shouldAddReceivedRecordsToNodeTableButNotNodeBuckets() {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
-    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(distance));
+    final FindNodeResponseHandler handler =
+        new FindNodeResponseHandler(singletonList(distance), ALLOW_ALL);
 
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
@@ -50,10 +55,25 @@ class FindNodeResponseHandlerTest {
   }
 
   @Test
+  public void shouldRejectReceivedRecordsThatAreDisallowed() {
+    final NodeInfo nodeInfo = TestUtil.generateNode(9000);
+    final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
+    final FindNodeResponseHandler handler =
+        new FindNodeResponseHandler(singletonList(distance), DISALLOW_ALL);
+
+    final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
+    final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
+    assertThat(handler.handleResponseMessage(message, session)).isTrue();
+
+    verify(session, never()).onNodeRecordReceived(nodeInfo.getNodeRecord());
+  }
+
+  @Test
   public void shouldRejectReceivedRecordsThatAreInvalid() {
     final NodeInfo nodeInfo = TestUtil.generateInvalidNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
-    final FindNodeResponseHandler handler = new FindNodeResponseHandler(singletonList(distance));
+    final FindNodeResponseHandler handler =
+        new FindNodeResponseHandler(singletonList(distance), ALLOW_ALL);
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
     handler.handleResponseMessage(message, session);
@@ -66,7 +86,7 @@ class FindNodeResponseHandlerTest {
     final NodeInfo nodeInfo = TestUtil.generateNode(9000);
     final int distance = Functions.logDistance(PEER_ID, nodeInfo.getNodeRecord().getNodeId());
     final FindNodeResponseHandler handler =
-        new FindNodeResponseHandler(singletonList(distance + 1));
+        new FindNodeResponseHandler(singletonList(distance + 1), ALLOW_ALL);
     final List<NodeRecord> records = singletonList(nodeInfo.getNodeRecord());
     final NodesMessage message = new NodesMessage(REQUEST_ID, records.size(), records);
     handler.handleResponseMessage(message, session);
@@ -78,7 +98,7 @@ class FindNodeResponseHandlerTest {
   @ValueSource(ints = {-1, 0, 17})
   public void shouldRejectInvalidTotalPackets(final int numPackets) {
     final NodesMessage message = new NodesMessage(REQUEST_ID, numPackets, emptyList());
-    final FindNodeResponseHandler handler = new FindNodeResponseHandler(emptyList());
+    final FindNodeResponseHandler handler = new FindNodeResponseHandler(emptyList(), ALLOW_ALL);
     assertThatThrownBy(() -> handler.handleResponseMessage(message, session))
         .hasMessageContaining("Invalid number of total packets")
         .isInstanceOf(RuntimeException.class);


### PR DESCRIPTION
## PR Description
Implements an address access policy to allow library users to restrict which IP addresses are allowed for incoming and outgoing packets as well as for accepted node records.

## Fixed Issue(s)
https://github.com/ConsenSys/teku/issues/6242