### PR TITLE
Fixed NPE in node session

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -8,6 +8,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.ethereum.beacon.discovery.task.TaskStatus.AWAIT;
 import static org.ethereum.beacon.discovery.task.TaskStatus.SENT;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Map;
@@ -18,8 +19,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -18,6 +18,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -97,6 +99,7 @@ public class NodeSession {
         new ConcurrentHashMap<>());
   }
 
+  @VisibleForTesting
   NodeSession(
       final Bytes nodeId,
       final Optional<NodeRecord> nodeRecord,

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
@@ -6,13 +6,18 @@ package org.ethereum.beacon.discovery.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.apache.tuweni.bytes.Bytes;
@@ -142,6 +147,28 @@ public class NodeSessionTest {
 
     timeoutHandler.run();
     assertThat(session.getState()).isEqualTo(SessionState.INITIAL);
+  }
+
+  @Test
+  void cancelAllRequests_shouldContinueIfNotFound() {
+    final Bytes msgId = Bytes.random(2);
+    final Map<Bytes, RequestInfo> requestIdStatuses = spy(new HashMap<>());
+    doReturn(Set.of(msgId)).when(requestIdStatuses).keySet();
+
+    final NodeSession mySession =
+        new NodeSession(
+            nodeId,
+            Optional.empty(),
+            InetSocketAddress.createUnresolved("127.0.0.1", 2999),
+            nodeSessionManager,
+            localNodeRecordStore,
+            SECRET_KEY,
+            kBuckets,
+            outgoingPipeline,
+            new Random(1342),
+            expirationScheduler,
+            requestIdStatuses);
+    mySession.cancelAllRequests("BAD PANDA");
   }
 
   @Test


### PR DESCRIPTION
I'm not sure this can actually happen easily, but added guards around map entries coming back empty etc. given they're closing down we'll just log debug messages.

fixes #173 