### PR TITLE
Expose IdentitySchemaInterpreter.calculateNodeId

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaInterpreter.java
@@ -52,4 +52,6 @@ public interface IdentitySchemaInterpreter {
 
   NodeRecord createWithUpdatedCustomField(
       NodeRecord nodeRecord, String newAddress, Bytes value, SecretKey secretKey);
+
+  Bytes calculateNodeId(Bytes publicKey);
 }

--- a/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4Interpreter.java
@@ -37,7 +37,7 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
   private final LoadingCache<Bytes, Bytes> nodeIdCache =
       CacheBuilder.newBuilder()
           .maximumSize(4000)
-          .build(CacheLoader.from(IdentitySchemaV4Interpreter::calculateNodeId));
+          .build(CacheLoader.from(IdentitySchemaV4Interpreter::calculateNodeIdImpl));
 
   private static final ImmutableSet<String> ADDRESS_IP_V4_FIELD_NAMES =
       ImmutableSet.of(EnrField.IP_V4, EnrField.UDP);
@@ -74,7 +74,7 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
     return nodeIdCache.getUnchecked(pkey);
   }
 
-  private static Bytes calculateNodeId(final Bytes publicKey) {
+  private static Bytes calculateNodeIdImpl(final Bytes publicKey) {
     ECPoint pudDestPoint = Functions.publicKeyToPoint(publicKey);
     Bytes xPart =
         Bytes.wrap(
@@ -150,6 +150,11 @@ public class IdentitySchemaV4Interpreter implements IdentitySchemaInterpreter {
     final NodeRecord newRecord = NodeRecord.fromValues(this, nodeRecord.getSeq().add(1), fields);
     sign(newRecord, secretKey);
     return newRecord;
+  }
+
+  @Override
+  public Bytes calculateNodeId(final Bytes publicKey) {
+    return nodeIdCache.getUnchecked(publicKey);
   }
 
   private static Optional<InetSocketAddress> addressFromFields(

--- a/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
+++ b/src/test/java/org/ethereum/beacon/discovery/SimpleIdentitySchemaInterpreter.java
@@ -128,4 +128,11 @@ public class SimpleIdentitySchemaInterpreter implements IdentitySchemaInterprete
     sign(newRecord, secretKey);
     return newRecord;
   }
+
+  @Override
+  public Bytes calculateNodeId(final Bytes publicKey) {
+    final NodeRecord nodeRecord =
+        createNodeRecord(publicKey, new InetSocketAddress("127.0.0.1", 2));
+    return nodeRecord.getNodeId();
+  }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/IdentitySchemaV4InterpreterTest.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -282,6 +283,18 @@ class IdentitySchemaV4InterpreterTest {
     Bytes invalidEnrBytes = RLP.encode(writer -> nodeRecord.writeRlp(writer, true, keys));
     assertThatThrownBy(() -> NodeRecordFactory.DEFAULT.fromBytes(invalidEnrBytes))
         .isInstanceOf(DecodeException.class);
+  }
+
+  @Test
+  public void calculateNodeIdShouldMatchExpected() {
+    final Bytes expectedNodeId =
+        NodeRecordFactory.DEFAULT
+            .createFromValues(
+                UInt64.ZERO,
+                new EnrField(EnrField.PKEY_SECP256K1, PUB_KEY),
+                new EnrField(EnrField.ID, IdentitySchema.V4))
+            .getNodeId();
+    assertEquals(expectedNodeId, interpreter.calculateNodeId(PUB_KEY));
   }
 
   private Optional<InetSocketAddress> getTcpAddressForNodeRecordWithFields(


### PR DESCRIPTION
Needed for [teku#](https://github.com/Consensys/teku/pull/8641)
See https://github.com/zilm13/teku/blob/507ff36602bd68fac788e0d64748b407aedb5db4/networking/p2p/src/main/java/tech/pegasys/teku/networking/p2p/discovery/discv5/NodeRecordConverter.java#L41-L47