### PR TITLE
Fix concurrency issue on LocalNodeRecordStore

### DIFF
--- a/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
@@ -10,6 +10,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.junit.jupiter.api.Test;
@@ -17,23 +18,36 @@ import org.junit.jupiter.api.Test;
 public class LocalNodeRecordStoreTest {
 
   @Test
-  void testListenerIsCalled() {
+  public void testListenerIsNotCalledWhenSocketAddressHasNotChanged() {
+    List<Update> listenerCalls = new ArrayList<>();
+
+    NodeRecord nodeRecord =
+        SimpleIdentitySchemaInterpreter.createNodeRecord(
+            Bytes32.leftPad(Bytes.ofUnsignedInt(1)), new InetSocketAddress("127.0.0.1", 9001));
+
+    LocalNodeRecordStore recordStore =
+        new LocalNodeRecordStore(
+            nodeRecord, null, (o, n) -> listenerCalls.add(new Update(o, n)), ADDRESS_UPDATER);
+    assertThat(listenerCalls).isEmpty();
+
+    recordStore.onSocketAddressChanged(nodeRecord.getUdpAddress().orElseThrow());
+
+    // No updates propagated to listener
+    assertThat(listenerCalls).isEmpty();
+
+    // Record has not changed
+    assertThat(recordStore.getLocalNodeRecord()).isEqualTo(nodeRecord);
+  }
+
+  @Test
+  void testListenerIsCalledWhenSocketAddressHasChanged() {
     NodeRecord nodeRecord1 =
         SimpleIdentitySchemaInterpreter.createNodeRecord(
-            Bytes.ofUnsignedInt(1), new InetSocketAddress("127.0.0.1", 9001));
+            Bytes32.leftPad(Bytes.ofUnsignedInt(1)), new InetSocketAddress("127.0.0.1", 9001));
     NodeRecord nodeRecord2 =
         SimpleIdentitySchemaInterpreter.createNodeRecord(
-            Bytes.ofUnsignedInt(2), new InetSocketAddress("127.0.0.1", 9002));
+            Bytes32.leftPad(Bytes.ofUnsignedInt(2)), new InetSocketAddress("127.0.0.1", 9002));
 
-    class Update {
-      NodeRecord oldRec;
-      NodeRecord newRec;
-
-      public Update(NodeRecord oldRec, NodeRecord newRec) {
-        this.oldRec = oldRec;
-        this.newRec = newRec;
-      }
-    }
     List<Update> listenerCalls = new ArrayList<>();
     LocalNodeRecordStore recordStore =
         new LocalNodeRecordStore(
@@ -42,18 +56,63 @@ public class LocalNodeRecordStoreTest {
 
     recordStore.onSocketAddressChanged(nodeRecord2.getUdpAddress().orElseThrow());
 
+    // Update was propagated to listener with correct values
     assertThat(listenerCalls).hasSize(1);
     assertThat(listenerCalls.get(0).oldRec).isEqualTo(nodeRecord1);
     assertThat(listenerCalls.get(0).newRec.getUdpAddress())
         .contains(nodeRecord2.getUdpAddress().orElseThrow());
+
+    // Value has been updated on recordStore
     assertThat(recordStore.getLocalNodeRecord().getUdpAddress().orElseThrow())
         .isEqualTo(nodeRecord2.getUdpAddress().get());
+  }
+
+  @Test
+  void testListenerIsNotCalledWhenCustomFieldValueHasNotChanged() {
+    NodeRecord nodeRecord =
+        SimpleIdentitySchemaInterpreter.createNodeRecord(
+                Bytes32.leftPad(Bytes.ofUnsignedInt(1)), new InetSocketAddress("127.0.0.1", 9001))
+            .withUpdatedCustomField("fieldName", Bytes.fromHexString("0x111111"), null);
+
+    List<Update> listenerCalls = new ArrayList<>();
+    LocalNodeRecordStore recordStore =
+        new LocalNodeRecordStore(
+            nodeRecord, null, (o, n) -> listenerCalls.add(new Update(o, n)), ADDRESS_UPDATER);
+    assertThat(listenerCalls).isEmpty();
+
+    recordStore.onCustomFieldValueChanged("fieldName", Bytes.fromHexString("0x111111"));
+
+    // No updates propagated to listener
+    assertThat(listenerCalls).hasSize(0);
+
+    // Record has not changed
+    assertThat(recordStore.getLocalNodeRecord()).isEqualTo(nodeRecord);
+  }
+
+  @Test
+  void testListenerIsCalledWhenCustomFieldValueHasChanged() {
+    NodeRecord nodeRecord =
+        SimpleIdentitySchemaInterpreter.createNodeRecord(
+            Bytes32.leftPad(Bytes.ofUnsignedInt(1)), new InetSocketAddress("127.0.0.1", 9001));
+
+    List<Update> listenerCalls = new ArrayList<>();
+    LocalNodeRecordStore recordStore =
+        new LocalNodeRecordStore(
+            nodeRecord, null, (o, n) -> listenerCalls.add(new Update(o, n)), ADDRESS_UPDATER);
+    assertThat(listenerCalls).isEmpty();
 
     recordStore.onCustomFieldValueChanged("fieldName", Bytes.fromHexString("0x112233"));
 
-    assertThat(listenerCalls).hasSize(2);
-    assertThat(listenerCalls.get(1).oldRec).isEqualTo(listenerCalls.get(0).newRec);
-    assertThat(listenerCalls.get(1).newRec.get("fieldName"))
+    // Update was propagated to listener with correct values
+    assertThat(listenerCalls).hasSize(1);
+    assertThat(listenerCalls.get(0).oldRec).isEqualTo(nodeRecord);
+    assertThat(listenerCalls.get(0).newRec.get("fieldName"))
+        .isEqualTo(Bytes.fromHexString("0x112233"));
+
+    // Value has been updated on recordStore
+    assertThat(recordStore.getLocalNodeRecord().get("fieldName"))
         .isEqualTo(Bytes.fromHexString("0x112233"));
   }
+
+  private record Update(NodeRecord oldRec, NodeRecord newRec) {}
 }


### PR DESCRIPTION
## PR Description
- Prevents concurrency issue on LocalNodeRecordStore when checking and comparing the latest record;
- Updated logic to only notify the record listener updates when the record is actually updated (address or custom field);
- Updated unit tests to reflect changes in listener update;

## Fixed Issue(s)
fixes #190 
