### PR TITLE
Downgrade routine peer-interaction logs from DEBUG to TRACE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,20 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # wait 7 days for stability      
+    cooldown:
+      default-days: 7
+
+    # grouping: bundle updates into one PR rather than one at a time
+    groups:
+      java-dependencies:
+        patterns:
+          - "*" 
+        # Optional: exclude major versions so we can review these
+        # update-types:
+        #   - "minor"
+        #   - "patch"
+
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
     {
       "description": "Pin all GitHub Actions to SHA digests",
       "matchManagers": ["github-actions"],
-      "pinDigests": true
+      "pinDigests": true,
+      "minimumReleaseAge": "7 days",
+      "groupName": "Renovatebot GHA Updates"
     }
   ]
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/BadPacketHandler.java
@@ -26,7 +26,7 @@ public class BadPacketHandler implements EnvelopeHandler {
                 "Envelope %s in BadPacketHandler, requirements are satisfied!",
                 envelope.getIdString()));
 
-    LOG.debug(
+    LOG.trace(
         () ->
             String.format(
                 "Bad packet: %s in envelope #%s: %s",

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -70,7 +70,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
     try {
 
       if (session.getWhoAreYouChallenge().isEmpty()) {
-        LOG.debug(String.format("Outbound WhoAreYou challenge not found for session %s", session));
+        LOG.trace(String.format("Outbound WhoAreYou challenge not found for session %s", session));
         markHandshakeAsFailed(envelope, session);
         return;
       }
@@ -90,7 +90,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
 
       Optional<NodeRecord> enr = packet.getHeader().getAuthData().getNodeRecord(nodeRecordFactory);
       if (!enr.map(NodeRecord::isValid).orElse(true)) {
-        LOG.debug(
+        LOG.trace(
             String.format(
                 "Node record not valid for message [%s] from node %s in status %s",
                 packet, session.getNodeRecord(), session.getState()));
@@ -100,7 +100,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
       final Optional<NodeRecord> nodeRecordMaybe = session.getNodeRecord().or(() -> enr);
       // Check the node record matches the ID we expect
       if (!nodeRecordMaybe.map(r -> r.getNodeId().equals(session.getNodeId())).orElse(false)) {
-        LOG.debug(
+        LOG.trace(
             "Incorrect node ID for message [{}] from node {} in status {}",
             packet,
             session.getNodeRecord(),
@@ -108,7 +108,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
         markHandshakeAsFailed(envelope, session);
         return;
       } else if (!enr.map(addressAccessPolicy::allow).orElse(true)) {
-        LOG.debug(
+        LOG.trace(
             "Rejecting handshake from node {} because the ENR was disallowed: {}",
             session.getNodeRecord(),
             enr);
@@ -127,7 +127,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
                   (Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1));
 
       if (!idNonceVerifyResult) {
-        LOG.debug(
+        LOG.trace(
             String.format(
                 "ID signature not valid for message [%s] from node %s in status %s",
                 packet, session.getNodeRecord(), session.getState()));
@@ -145,7 +145,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
       enr.ifPresent(session::onNodeRecordReceived);
       NextTaskHandler.tryToSendAwaitTaskIfAny(session, outgoingPipeline, scheduler);
     } catch (Exception ex) {
-      LOG.debug(
+      LOG.trace(
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, session.getNodeRecord(), session.getState()),

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -69,7 +69,7 @@ public class MessagePacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               packet, session.getNodeRecord(), session.getState());
-      LOG.debug(error, ex);
+      LOG.trace(error, ex);
       envelope.remove(Field.PACKET_MESSAGE);
       envelope.put(Field.BAD_PACKET, packet);
     } catch (Throwable t) {

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
@@ -47,7 +47,7 @@ public class OutgoingParcelHandler implements EnvelopeHandler {
       if (parcel.getPacket().getBytes().size() > IncomingDataPacker.MAX_PACKET_SIZE) {
         LOG.error("Outgoing packet is too large, dropping it: {}", parcel.getPacket());
       } else if (!addressAccessPolicy.allow(parcel.getDestination())) {
-        LOG.debug(
+        LOG.trace(
             "Dropping outgoing packet to disallowed destination: {}", parcel.getDestination());
       } else {
         outgoingSink.next(parcel);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
@@ -30,7 +30,7 @@ public class PacketSourceFilter implements EnvelopeHandler {
     final InetSocketAddress sender = envelope.get(Field.REMOTE_SENDER);
     if (!addressAccessPolicy.allow(sender)) {
       envelope.remove(Field.INCOMING);
-      LOG.debug("Ignoring message from disallowed source {}", sender);
+      LOG.trace("Ignoring message from disallowed source {}", sender);
     }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
@@ -61,7 +61,7 @@ public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
           String.format(
               "Failed to read message [%s] from node %s in status %s",
               unknownPacket, session.getNodeRecord(), session.getState());
-      LOG.debug(error, ex);
+      LOG.trace(error, ex);
       envelope.put(Field.BAD_PACKET, unknownPacket);
       envelope.put(Field.BAD_EXCEPTION, ex);
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -68,7 +68,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
       boolean nonceMatches =
           session.getLastOutboundNonce().map(whoAreYouNonce::equals).orElse(false);
       if (!nonceMatches) {
-        LOG.debug(
+        LOG.trace(
             "Verification not passed for message [{}] from node {} in status {}",
             whoAreYouPacket,
             nodeRecord,

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/info/FindNodeResponseHandler.java
@@ -73,7 +73,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
 
   private boolean isValid(final NodeRecord record) {
     if (!record.isValid()) {
-      LOG.debug("Rejecting invalid node record {}", record);
+      LOG.trace("Rejecting invalid node record {}", record);
       return false;
     }
     return true;
@@ -82,7 +82,7 @@ public class FindNodeResponseHandler implements MultiPacketResponseHandler<Nodes
   private boolean hasCorrectDistance(final NodeSession session, final NodeRecord nodeRecordV5) {
     final int actualDistance = Functions.logDistance(nodeRecordV5.getNodeId(), session.getNodeId());
     if (!distances.contains(actualDistance)) {
-      LOG.debug(
+      LOG.trace(
           "Rejecting node record {} received from {} because distance was not in {}.",
           nodeRecordV5.getNodeId(),
           session.getNodeId(),

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -234,7 +234,7 @@ public class NodeSession {
 
   /** Updates request info. Thread-safe. */
   public synchronized void cancelAllRequests(final String message) {
-    LOG.debug(() -> String.format("Cancelling all requests in session %s", this));
+    LOG.trace(() -> String.format("Cancelling all requests in session %s", this));
     final Set<Bytes> requestIdsCopy = new HashSet<>(requestIdStatuses.keySet());
     requestIdsCopy.forEach(
         requestId -> {


### PR DESCRIPTION
Demotes 16 `LOG.debug()` calls to `LOG.trace()` across 9 Discovery v5 handler
classes. All 16 describe peer-caused events our node already handled correctly
(bad packets, failed handshakes, policy rejections, session timeouts) and were
producing ~114 messages/minute on mainnet, swamping `--logging=DEBUG` output.

Messages remain fully visible at `--logging=TRACE`. No `LOG.warn`/`error`/`info`
calls are touched.

Full rationale, measurements, and file-by-file breakdown: #<ISSUE_NUMBER>
Downstream: [besu-eth/besu#9691](https://github.com/hyperledger/besu/issues/9691)

### Deliberately left at DEBUG
Two `LOG.debug` calls in `NodeSession#cancelAllRequests` they signal possible
local-code issues (unexpected cleanup exception, race on `requestIdStatuses`),
not peer behavior.

Closed #214 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log-level-only changes in discovery handlers; no functional behavior, state transitions, or error handling paths are modified.
> 
> **Overview**
> Reduces noise in Discovery v5 by demoting routine peer-driven events from `DEBUG` to `TRACE` across several packet/session handlers.
> 
> This primarily affects logs for bad packets/decrypt failures, handshake validation failures, disallowed sources/destinations, and rejected `FINDNODE` results, keeping `WARN`/`ERROR` behavior unchanged while making `--logging=DEBUG` output less chatty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62fc1ea13003b336bb3032bf3d2cfaf3b26c5382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->