### PR TITLE
Revert "fix: prevent pipeline errors from killing Reactor subscriptio…

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
@@ -29,18 +29,7 @@ public class PipelineImpl implements Pipeline {
   public synchronized Pipeline build() {
     started.set(true);
     for (EnvelopeHandler handler : envelopeHandlers) {
-      pipeline =
-          pipeline.doOnNext(
-              envelope -> {
-                try {
-                  handler.handle(envelope);
-                } catch (Throwable t) {
-                  LOG.warn(
-                      "Unexpected error in pipeline handler {}",
-                      handler.getClass().getSimpleName(),
-                      t);
-                }
-              });
+      pipeline = pipeline.doOnNext(handler::handle);
     }
     Flux.from(pipeline)
         .onErrorContinue(

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -151,13 +151,6 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
               packet, session.getNodeRecord(), session.getState()),
           ex);
       markHandshakeAsFailed(envelope, session);
-    } catch (Throwable t) {
-      LOG.warn(
-          "Unexpected error while processing handshake [{}] from node {}",
-          packet,
-          session.getNodeRecord(),
-          t);
-      markHandshakeAsFailed(envelope, session);
     }
   }
 


### PR DESCRIPTION
…n (#205)"

This reverts commit 72315ae630f05b31dcdaefc91e2e502a2b365b8d.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pipeline error handling so exceptions from `EnvelopeHandler.handle` and handshake processing are no longer broadly caught/logged, which could reintroduce subscriber termination or dropped messages depending on Reactor `onErrorContinue` behavior.
> 
> **Overview**
> Reverts prior defensive error handling by removing the per-handler `try/catch` wrapper in `PipelineImpl.build()`, letting `EnvelopeHandler.handle()` exceptions propagate to Reactor and be handled only by the downstream `onErrorContinue`.
> 
> Also tightens `HandshakeMessagePacketHandler` to catch only `Exception` (dropping the `Throwable` catch), so unexpected `Error`/fatal throwables during handshake will now propagate instead of being logged and treated as a handshake failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef6d7911c29bc5b169f43c541d30c0d418f5b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->