### PR TITLE
Add AbstractSkippingEnvelopeHandler so all handlers will skip BAD_PACKET

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandler.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.pipeline;
+
+/**
+ * Base class for {@link EnvelopeHandler}s that should be skipped once an envelope has been marked
+ * with {@link Field#BAD_PACKET}. Subclasses implement {@link #handlePacket(Envelope)} and get the
+ * skip behaviour for free; the terminal bad-packet handler implements {@link EnvelopeHandler}
+ * directly.
+ */
+public abstract class AbstractSkippingEnvelopeHandler implements EnvelopeHandler {
+
+  @Override
+  public final void handle(final Envelope envelope) {
+    if (envelope.contains(Field.BAD_PACKET)) {
+      return;
+    }
+    handlePacket(envelope);
+  }
+
+  protected abstract void handlePacket(Envelope envelope);
+}

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -13,8 +13,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.AddressAccessPolicy;
 import org.ethereum.beacon.discovery.message.V5Message;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.Pipeline;
@@ -27,7 +27,7 @@ import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.Functions;
 
 /** Handles {@link HandshakeMessagePacket} in {@link Field#PACKET_HANDSHAKE} field */
-public class HandshakeMessagePacketHandler implements EnvelopeHandler {
+public class HandshakeMessagePacketHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(HandshakeMessagePacketHandler.class);
   private final Pipeline outgoingPipeline;
   private final Scheduler scheduler;
@@ -49,7 +49,7 @@ public class HandshakeMessagePacketHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.PACKET_HANDSHAKE, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/IncomingDataPacker.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/IncomingDataPacker.java
@@ -9,15 +9,15 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.packet.RawPacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.DecodeException;
 
 /** Handles raw BytesValue incoming data in {@link Field#INCOMING} */
-public class IncomingDataPacker implements EnvelopeHandler {
+public class IncomingDataPacker extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(IncomingDataPacker.class);
   public static final int MAX_PACKET_SIZE = 1280;
   public static final int MIN_PACKET_SIZE = 63;
@@ -28,7 +28,7 @@ public class IncomingDataPacker implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.INCOMING, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessageHandler.java
@@ -10,8 +10,8 @@ import org.ethereum.beacon.discovery.TalkHandler;
 import org.ethereum.beacon.discovery.message.V5Message;
 import org.ethereum.beacon.discovery.message.handler.EnrUpdateTracker.EnrUpdater;
 import org.ethereum.beacon.discovery.message.handler.ExternalAddressSelector;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.processor.DiscoveryV5MessageProcessor;
@@ -19,7 +19,7 @@ import org.ethereum.beacon.discovery.processor.MessageProcessor;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 
-public class MessageHandler implements EnvelopeHandler {
+public class MessageHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(MessageHandler.class);
   private final MessageProcessor messageProcessor;
 
@@ -36,7 +36,7 @@ public class MessageHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.MESSAGE, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/MessagePacketHandler.java
@@ -9,8 +9,8 @@ import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.message.V5Message;
 import org.ethereum.beacon.discovery.packet.MessagePacket;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
@@ -19,7 +19,7 @@ import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.DecryptException;
 
 /** Handles {@link MessagePacket} in {@link Field#PACKET_MESSAGE} field */
-public class MessagePacketHandler implements EnvelopeHandler {
+public class MessagePacketHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(MessagePacketHandler.class);
   private final NodeRecordFactory nodeRecordFactory;
 
@@ -28,7 +28,7 @@ public class MessagePacketHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.PACKET_MESSAGE, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NewTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NewTaskHandler.java
@@ -6,20 +6,20 @@ package org.ethereum.beacon.discovery.pipeline.handler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.info.Request;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 
 /** Enqueues task in session for any task found in {@link Field#REQUEST} */
-public class NewTaskHandler implements EnvelopeHandler {
+public class NewTaskHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(NewTaskHandler.class);
 
   @Override
   @SuppressWarnings("rawtypes")
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.REQUEST, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NextTaskHandler.java
@@ -11,8 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.message.V5Message;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.Pipeline;
@@ -23,7 +23,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession.SessionState;
 import org.ethereum.beacon.discovery.task.TaskStatus;
 
 /** Gets next request task in session and processes it */
-public class NextTaskHandler implements EnvelopeHandler {
+public class NextTaskHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(NextTaskHandler.class);
   private static final int DEFAULT_DELAY_MS = 1000;
   private static final int RANDOM_MESSAGE_SIZE = 128;
@@ -46,7 +46,7 @@ public class NextTaskHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -19,8 +19,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.crypto.Signer;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.Pipeline;
@@ -37,7 +37,7 @@ import org.ethereum.beacon.discovery.util.Functions;
  * Performs {@link Field#SESSION_LOOKUP} request. Looks up for Node session based on NodeId, which
  * should be in request field and stores it in {@link Field#SESSION} field.
  */
-public class NodeSessionManager implements EnvelopeHandler {
+public class NodeSessionManager extends AbstractSkippingEnvelopeHandler {
   private static final int SESSION_CLEANUP_DELAY_SECONDS = 180;
   private static final int REQUEST_CLEANUP_DELAY_SECONDS = 60;
   private static final Logger LOG = LogManager.getLogger(NodeSessionManager.class);
@@ -67,7 +67,7 @@ public class NodeSessionManager implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(final Envelope envelope) {
+  protected void handlePacket(final Envelope envelope) {
     if (!HandlerUtil.requireField(Field.SESSION_LOOKUP, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionRequestHandler.java
@@ -6,8 +6,8 @@ package org.ethereum.beacon.discovery.pipeline.handler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 
@@ -15,11 +15,11 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
  * Searches for node in {@link Field#NODE} and requests session resolving using {@link
  * Field#SESSION_LOOKUP}
  */
-public class NodeSessionRequestHandler implements EnvelopeHandler {
+public class NodeSessionRequestHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(NodeSessionRequestHandler.class);
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.NODE, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
@@ -8,8 +8,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.AddressAccessPolicy;
 import org.ethereum.beacon.discovery.network.NetworkParcel;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import reactor.core.publisher.FluxSink;
@@ -19,7 +19,7 @@ import reactor.core.publisher.FluxSink;
  * we have outgoing parcel at the very first stage. Handler pushes it to `outgoingSink` stream which
  * is linked with discovery client.
  */
-public class OutgoingParcelHandler implements EnvelopeHandler {
+public class OutgoingParcelHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(OutgoingParcelHandler.class);
 
   private final FluxSink<NetworkParcel> outgoingSink;
@@ -32,7 +32,7 @@ public class OutgoingParcelHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.INCOMING, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketDispatcherHandler.java
@@ -11,20 +11,20 @@ import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
 import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.schema.NodeSession;
 import org.ethereum.beacon.discovery.util.Utils;
 
 /** Matches the current session state and inbound packet */
-public class PacketDispatcherHandler implements EnvelopeHandler {
+public class PacketDispatcherHandler extends AbstractSkippingEnvelopeHandler {
 
   private static final Logger LOG = LogManager.getLogger(PacketDispatcherHandler.class);
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.SESSION, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/PacketSourceFilter.java
@@ -8,12 +8,12 @@ import java.net.InetSocketAddress;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.AddressAccessPolicy;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 
-public class PacketSourceFilter implements EnvelopeHandler {
+public class PacketSourceFilter extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(PacketSourceFilter.class);
 
   private final AddressAccessPolicy addressAccessPolicy;
@@ -23,7 +23,7 @@ public class PacketSourceFilter implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(final Envelope envelope) {
+  protected void handlePacket(final Envelope envelope) {
     if (!HandlerUtil.requireField(Field.REMOTE_SENDER, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
@@ -11,8 +11,8 @@ import org.ethereum.beacon.discovery.packet.Header;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket.WhoAreYouAuthData;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
@@ -22,12 +22,12 @@ import org.ethereum.beacon.discovery.type.Bytes12;
 import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.Functions;
 
-public class UnauthorizedMessagePacketHandler implements EnvelopeHandler {
+public class UnauthorizedMessagePacketHandler extends AbstractSkippingEnvelopeHandler {
 
   private static final Logger LOG = LogManager.getLogger(UnauthorizedMessagePacketHandler.class);
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.UNAUTHORIZED_PACKET_MESSAGE, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnknownPacketTagToSender.java
@@ -10,8 +10,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket;
 import org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket;
 import org.ethereum.beacon.discovery.packet.Packet;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 
@@ -20,11 +20,11 @@ import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
  * field of the packet. Next, puts it to the {@link Field#SESSION_LOOKUP} so sender session could be
  * resolved by another handler.
  */
-public class UnknownPacketTagToSender implements EnvelopeHandler {
+public class UnknownPacketTagToSender extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(UnknownPacketTagToSender.class);
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.PACKET, envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouPacketHandler.java
@@ -15,8 +15,8 @@ import org.ethereum.beacon.discovery.message.V5Message;
 import org.ethereum.beacon.discovery.packet.HandshakeMessagePacket.HandshakeAuthData;
 import org.ethereum.beacon.discovery.packet.Header;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.pipeline.Pipeline;
@@ -31,7 +31,7 @@ import org.ethereum.beacon.discovery.type.Bytes16;
 import org.ethereum.beacon.discovery.util.Functions;
 
 /** Handles {@link WhoAreYouPacket} in {@link Field#PACKET_WHOAREYOU} field */
-public class WhoAreYouPacketHandler implements EnvelopeHandler {
+public class WhoAreYouPacketHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(WhoAreYouPacketHandler.class);
 
   private final Pipeline outgoingPipeline;
@@ -43,7 +43,7 @@ public class WhoAreYouPacketHandler implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(final Envelope envelope) {
+  protected void handlePacket(final Envelope envelope) {
     if (!HandlerUtil.requireSessionWithNodeRecord(envelope)) {
       return;
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouSessionResolver.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/WhoAreYouSessionResolver.java
@@ -9,8 +9,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.packet.Packet;
 import org.ethereum.beacon.discovery.packet.WhoAreYouPacket;
+import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import org.ethereum.beacon.discovery.pipeline.EnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
 import org.ethereum.beacon.discovery.schema.NodeSession;
@@ -19,7 +19,7 @@ import org.ethereum.beacon.discovery.schema.NodeSession;
  * Resolves session using `nonceRepository` for `WHOAREYOU` packets which should be placed in {@link
  * Field#PACKET_WHOAREYOU}
  */
-public class WhoAreYouSessionResolver implements EnvelopeHandler {
+public class WhoAreYouSessionResolver extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(WhoAreYouSessionResolver.class);
   private final NodeSessionManager nodeSessionManager;
 
@@ -28,7 +28,7 @@ public class WhoAreYouSessionResolver implements EnvelopeHandler {
   }
 
   @Override
-  public void handle(Envelope envelope) {
+  protected void handlePacket(Envelope envelope) {
     if (!HandlerUtil.requireField(Field.PACKET, envelope)) {
       return;
     }

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.ethereum.beacon.discovery.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class AbstractSkippingEnvelopeHandlerTest {
+
+  private static final Field<String> MARKER = new Field<>("MARKER");
+
+  private static class CountingHandler extends AbstractSkippingEnvelopeHandler {
+    final AtomicInteger invocations = new AtomicInteger();
+
+    @Override
+    protected void handlePacket(final Envelope envelope) {
+      invocations.incrementAndGet();
+    }
+  }
+
+  @Test
+  void downstreamHandlersSkipEnvelopesMarkedAsBadPacket() {
+    final EnvelopeHandler markBad =
+        envelope -> {
+          envelope.put(Field.BAD_PACKET, new Object());
+          envelope.put(Field.BAD_EXCEPTION, new RuntimeException("bad"));
+        };
+    final CountingHandler downstream = new CountingHandler();
+    final AtomicInteger terminalInvocations = new AtomicInteger();
+    // Terminal handler implements EnvelopeHandler directly, so it still sees bad packets.
+    final EnvelopeHandler terminal = envelope -> terminalInvocations.incrementAndGet();
+
+    final Pipeline pipeline =
+        new PipelineImpl()
+            .addHandler(markBad)
+            .addHandler(downstream)
+            .addHandler(terminal)
+            .build();
+
+    pipeline.push(new Envelope());
+
+    assertThat(downstream.invocations).hasValue(0);
+    assertThat(terminalInvocations).hasValue(1);
+  }
+
+  @Test
+  void healthyEnvelopesReachDownstreamSkippingHandlers() {
+    final EnvelopeHandler markClean = envelope -> envelope.put(MARKER, "ok");
+    final CountingHandler downstream =
+        new CountingHandler() {
+          @Override
+          protected void handlePacket(final Envelope envelope) {
+            assertThat(envelope.get(MARKER)).isEqualTo("ok");
+            super.handlePacket(envelope);
+          }
+        };
+
+    final Pipeline pipeline =
+        new PipelineImpl().addHandler(markClean).addHandler(downstream).build();
+
+    pipeline.push(new Envelope());
+
+    assertThat(downstream.invocations).hasValue(1);
+  }
+
+  @Test
+  void handlerChainStopsAtFirstBadMarking() {
+    final CountingHandler first = new CountingHandler();
+    final EnvelopeHandler markBadMidway =
+        envelope -> envelope.put(Field.BAD_PACKET, new Object());
+    final CountingHandler last = new CountingHandler();
+
+    final Pipeline pipeline =
+        new PipelineImpl()
+            .addHandler(first)
+            .addHandler(markBadMidway)
+            .addHandler(last)
+            .build();
+
+    pipeline.push(new Envelope());
+
+    assertThat(first.invocations).hasValue(1);
+    assertThat(last.invocations).hasValue(0);
+  }
+}

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/AbstractSkippingEnvelopeHandlerTest.java
@@ -35,11 +35,7 @@ class AbstractSkippingEnvelopeHandlerTest {
     final EnvelopeHandler terminal = envelope -> terminalInvocations.incrementAndGet();
 
     final Pipeline pipeline =
-        new PipelineImpl()
-            .addHandler(markBad)
-            .addHandler(downstream)
-            .addHandler(terminal)
-            .build();
+        new PipelineImpl().addHandler(markBad).addHandler(downstream).addHandler(terminal).build();
 
     pipeline.push(new Envelope());
 
@@ -70,16 +66,11 @@ class AbstractSkippingEnvelopeHandlerTest {
   @Test
   void handlerChainStopsAtFirstBadMarking() {
     final CountingHandler first = new CountingHandler();
-    final EnvelopeHandler markBadMidway =
-        envelope -> envelope.put(Field.BAD_PACKET, new Object());
+    final EnvelopeHandler markBadMidway = envelope -> envelope.put(Field.BAD_PACKET, new Object());
     final CountingHandler last = new CountingHandler();
 
     final Pipeline pipeline =
-        new PipelineImpl()
-            .addHandler(first)
-            .addHandler(markBadMidway)
-            .addHandler(last)
-            .build();
+        new PipelineImpl().addHandler(first).addHandler(markBadMidway).addHandler(last).build();
 
     pipeline.push(new Envelope());
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description

We have errors like this in logs:
```
{"@timestamp":"2026-04-22T03:47:37,098","level":"WARN","thread":"nioEventLoopGroup-4-1","class":"PipelineImpl","message":"Unexpected error in pipeline handler UnknownPacketTagToSender","throwable":"java.lang.ClassCastException: class org.ethereum.beacon.discovery.packet.impl.WhoAreYouPacketImpl cannot be cast to class org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket (org.ethereum.beacon.discovery.packet.impl.WhoAreYouPacketImpl and org.ethereum.beacon.discovery.packet.OrdinaryMessagePacket are in unnamed module of loader 'app')\n\tat org.ethereum.beacon.discovery.pipeline.handler.UnknownPacketTagToSender.handle(UnknownPacketTagToSender.java:46)\n\tat org.ethereum.beacon.discovery.pipeline.PipelineImpl.lambda$build$0(PipelineImpl.java:36)\n\tat reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:489)\n\tat reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:503)\n\tat reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:503)\n\tat reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:503)\n\tat reactor.core.publisher.FluxReplay$SizeBoundReplayBuffer.replayNormal(FluxReplay.java:877)\n\tat reactor.core.publisher.FluxReplay$SizeBoundReplayBuffer.replay(FluxReplay.java:965)\n\tat reactor.core.publisher.ReplayProcessor.tryEmitNext(ReplayProcessor.java:508)\n\tat reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:27)\n\tat reactor.core.publisher.ReplayProcessor.onNext(ReplayProcessor.java:495)\n\tat reactor.core.publisher.FluxCreate$IgnoreSink.next(FluxCreate.java:704)\n\tat reactor.core.publisher.FluxCreate$SerializedFluxSink.next(FluxCreate.java:163)\n\tat org.ethereum.beacon.discovery.pipeline.PipelineImpl.push(PipelineImpl.java:63)\n\tat reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:489)\n\tat reactor.core.publisher.FluxReplay$SizeBoundReplayBuffer.replayNormal(FluxReplay.java:877)\n\tat reactor.core.publisher.FluxReplay$SizeBoundReplayBuffer.replay(FluxReplay.java:965)\n\tat reactor.core.publisher.ReplayProcessor.tryEmitNext(ReplayProcessor.java:508)\n\tat reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:27)\n\tat reactor.core.publisher.ReplayProcessor.onNext(ReplayProcessor.java:495)\n\tat reactor.core.publisher.FluxCreate$IgnoreSink.next(FluxCreate.java:704)\n\tat reactor.core.publisher.FluxCreate$SerializedFluxSink.next(FluxCreate.java:163)\n\tat org.ethereum.beacon.discovery.network.IncomingMessageSink.channelRead0(IncomingMessageSink.java:31)\n\tat org.ethereum.beacon.discovery.network.IncomingMessageSink.channelRead0(IncomingMessageSink.java:20)\n\tat io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)\n\tat io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)\n\tat io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)\n\tat io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)\n\tat io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)\n\tat io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)\n\tat io.netty.handler.traffic.AbstractTrafficShapingHandler.channelRead(AbstractTrafficShapingHandler.java:506)\n\tat io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)\n\tat io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)\n\tat io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)\n\tat io.netty.channel.nio.AbstractNioMessageChannel$NioMessageUnsafe.read(AbstractNioMessageChannel.java:100)\n\tat io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)\n\tat io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)\n\tat io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)\n\tat io.netty.channel.nio.NioIoHandler.processSelectedKeysOptimized(NioIoHandler.java:571)\n\tat io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:512)\n\tat io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)\n\tat io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)\n\tat io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.base/java.lang.Thread.run(Thread.java:1583)\n"}
```

It happens because WhoAreYou handler in pipeline was not able to parse WHOAREYOU packet, marked it with BAD_PACKET, next this packet arrives in `UnknownPacketTagToSender` handler, which is just down in the pipeline and `UnknownPacketTagToSender` just doesn't expect this type of packet at all and throws an exception. For me the proper fix would be to make all handlers ignoring any packet which is marked as a `BAD_PACKET` except bad packets handler. That idea is implemented in this PR

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is narrowly scoped to pipeline error handling (early-exit on `BAD_PACKET`) and is covered by new unit tests; minimal impact on core protocol logic beyond skipping post-error processing.
> 
> **Overview**
> Introduces `AbstractSkippingEnvelopeHandler`, a new base handler that short-circuits processing when an envelope has been marked with `Field.BAD_PACKET`.
> 
> Updates the main discovery pipeline handlers (packet parsing, session resolution, dispatch, and message/task handlers) to extend this base class and move their logic into `handlePacket`, so only the terminal `BadPacketHandler` (still implementing `EnvelopeHandler` directly) continues to observe and log bad packets.
> 
> Adds unit tests verifying that once `BAD_PACKET` is set, downstream skipping handlers are not invoked, while non-skipping terminal handlers still run and healthy envelopes continue through the chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7468e83a69f418914ca2afb0f4b7bfa5a0ca99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->