### PR TITLE
remove gradle config from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "gradle", "gradle-wrapper"],
+  "enabledManagers": ["github-actions"],
   "dependencyDashboard": false,
   "packageRules": [
     {
@@ -12,18 +12,6 @@
       "pinDigests": true,
       "minimumReleaseAge": "7 days",
       "groupName": "Renovatebot GHA Updates"
-    },
-    {
-      "description": "Group all Gradle wrapper updates into a single PR",
-      "matchManagers": ["gradle-wrapper"],
-      "minimumReleaseAge": "7 days",
-      "groupName": "Renovatebot Gradle Wrapper Updates"
-    },
-    {
-      "description": "Group all Gradle dependency updates into a single PR",
-      "matchManagers": ["gradle"],
-      "minimumReleaseAge": "7 days",
-      "groupName": "Renovatebot Gradle Updates"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/discovery/blob/master/CONTRIBUTING.md -->

## PR Description
remove gradle config from renovate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just stops Renovate from creating Gradle/Gradle-wrapper update PRs; no runtime code is affected.
> 
> **Overview**
> Renovate is now configured to **only** manage GitHub Actions updates by removing the `gradle` and `gradle-wrapper` managers and their grouping rules.
> 
> Gradle dependency and wrapper update PRs will no longer be created; GitHub Actions updates remain pinned to digests and grouped as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8eb5dc629a3130eb0e60bba1d61daa4427bf6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->