### PR TITLE
Fix IPv6 outbound dial bootstrap

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -9,6 +9,7 @@ import static org.ethereum.beacon.discovery.util.Utils.RECOVERABLE_ERRORS_PREDIC
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
@@ -92,13 +93,22 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
     final NodeRecord homeNodeRecord = localNodeRecordStore.getLocalNodeRecord();
 
     this.discoveryServers = discoveryServers;
+    // Detect whether any of the bound discovery servers is listening on IPv6. The session manager
+    // uses this to allow IPv6 outbound dialing when the home record has not (yet) advertised IPv6
+    // — required for IPv6 external-address auto-discovery to bootstrap.
+    final boolean ipv6BindAvailable =
+        discoveryServers.stream()
+            .map(NettyDiscoveryServer::getListenAddress)
+            .map(InetSocketAddress::getAddress)
+            .anyMatch(addr -> addr instanceof Inet6Address);
     nodeSessionManager =
         new NodeSessionManager(
             localNodeRecordStore,
             signer,
             nodeBucketStorage,
             outgoingPipeline,
-            expirationSchedulerFactory);
+            expirationSchedulerFactory,
+            ipv6BindAvailable);
     incomingPipeline
         .addHandler(new PacketSourceFilter(addressAccessPolicy))
         .addHandler(new IncomingDataPacker(homeNodeRecord.getNodeId()))

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManager.java
@@ -44,6 +44,7 @@ public class NodeSessionManager extends AbstractSkippingEnvelopeHandler {
   private final LocalNodeRecordStore localNodeRecordStore;
   private final Signer signer;
   private final KBuckets nodeBucketStorage;
+  private final boolean ipv6BindAvailable;
   private final Map<SessionKey, NodeSession> recentSessions = new ConcurrentHashMap<>();
   private final Map<Bytes12, NodeSession> lastNonceToSession = new ConcurrentHashMap<>();
   private final Pipeline outgoingPipeline;
@@ -55,11 +56,13 @@ public class NodeSessionManager extends AbstractSkippingEnvelopeHandler {
       final Signer signer,
       final KBuckets nodeBucketStorage,
       final Pipeline outgoingPipeline,
-      final ExpirationSchedulerFactory expirationSchedulerFactory) {
+      final ExpirationSchedulerFactory expirationSchedulerFactory,
+      final boolean ipv6BindAvailable) {
     this.localNodeRecordStore = localNodeRecordStore;
     this.signer = signer;
     this.nodeBucketStorage = nodeBucketStorage;
     this.outgoingPipeline = outgoingPipeline;
+    this.ipv6BindAvailable = ipv6BindAvailable;
     this.sessionExpirationScheduler =
         expirationSchedulerFactory.create(SESSION_CLEANUP_DELAY_SECONDS, TimeUnit.SECONDS);
     this.requestExpirationScheduler =
@@ -174,11 +177,14 @@ public class NodeSessionManager extends AbstractSkippingEnvelopeHandler {
               final NodeRecord homeNodeRecord = localNodeRecordStore.getLocalNodeRecord();
               final Optional<InetSocketAddress> homeUdpAddress = homeNodeRecord.getUdpAddress();
               final Optional<InetSocketAddress> homeUdp6Address = homeNodeRecord.getUdp6Address();
-              // Check for dual-stack and prefer IPv6 if available, otherwise check IPv6, then
-              // default to IPv4
-              if (homeUdpAddress.isPresent() && homeUdp6Address.isPresent()) {
+              // Prefer IPv6 outbound when the home record advertises IPv6 OR when an IPv6 socket
+              // is bound but the home record has not (yet) advertised IPv6 — the latter case
+              // matters for IPv6 external-address auto-discovery, where we must dial IPv6 in order
+              // to receive PONGs reporting our IPv6 source address.
+              final boolean preferIpv6Outbound = homeUdp6Address.isPresent() || ipv6BindAvailable;
+              if (homeUdpAddress.isPresent() && preferIpv6Outbound) {
                 return nodeRecord.getUdp6Address().or(nodeRecord::getUdpAddress);
-              } else if (homeUdp6Address.isPresent()) {
+              } else if (preferIpv6Outbound) {
                 return nodeRecord.getUdp6Address();
               } else {
                 return nodeRecord.getUdpAddress();

--- a/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
+++ b/src/test/java/org/ethereum/beacon/discovery/TestManagerWrapper.java
@@ -3,6 +3,7 @@
  */
 package org.ethereum.beacon.discovery;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -151,9 +152,11 @@ public class TestManagerWrapper {
             .signer(new DefaultSigner(keyPair.secretKey()))
             .address(LOCALHOST, port)
             .build();
+    final NettyDiscoveryServer mockServer = Mockito.mock(NettyDiscoveryServer.class);
+    Mockito.when(mockServer.getListenAddress()).thenReturn(new InetSocketAddress(LOCALHOST, port));
     DiscoverySystemBuilder builder = new DiscoverySystemBuilder();
     builder
-        .discoveryServer(Mockito.mock(NettyDiscoveryServer.class))
+        .discoveryServer(mockServer)
         .localNodeRecord(nodeRecord)
         .signer(new DefaultSigner(keyPair.secretKey()))
         .retryTimeout(RETRY_TIMEOUT)

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
@@ -7,7 +7,10 @@ package org.ethereum.beacon.discovery.pipeline.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.Executors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1.SecretKey;
@@ -54,7 +57,8 @@ class NodeSessionManagerTest {
           new DefaultSigner(STATIC_NODE_SECRET),
           nodeBucketStorage,
           outgoingPipeline,
-          expirationSchedulerFactory);
+          expirationSchedulerFactory,
+          false);
 
   @AfterEach
   public void tearDown() {
@@ -116,6 +120,48 @@ class NodeSessionManagerTest {
   }
 
   @Test
+  public void shouldDialPeerOverIpv6WhenIpv6BindAvailableEvenIfHomeRecordIsIpv4Only()
+      throws UnknownHostException {
+    final NodeSessionManager ipv6BindAvailableHandler =
+        new NodeSessionManager(
+            new LocalNodeRecordStore(
+                homeNodeRecord,
+                new DefaultSigner(homeNodeInfo.getSecretKey()),
+                NodeRecordListener.NOOP,
+                NewAddressHandler.NOOP),
+            new DefaultSigner(STATIC_NODE_SECRET),
+            nodeBucketStorage,
+            outgoingPipeline,
+            expirationSchedulerFactory,
+            true);
+
+    final InetSocketAddress peerIpv4 = new InetSocketAddress("192.0.2.1", 30303);
+    final InetSocketAddress peerIpv6 =
+        new InetSocketAddress(Inet6Address.getByName("2001:db8::1"), 30304);
+    final NodeRecord dualStackPeer = createDualStackPeerRecord(peerIpv4, peerIpv6);
+
+    final NodeSession session = lookupSessionForOutgoingMessage(dualStackPeer, ipv6BindAvailableHandler);
+
+    assertThat(session).isNotNull();
+    assertThat(session.getRemoteAddress().getAddress()).isInstanceOf(Inet6Address.class);
+    assertThat(session.getRemoteAddress()).isEqualTo(peerIpv6);
+  }
+
+  @Test
+  public void shouldDialPeerOverIpv4WhenIpv6BindNotAvailableAndHomeRecordIsIpv4Only()
+      throws UnknownHostException {
+    final InetSocketAddress peerIpv4 = new InetSocketAddress("192.0.2.1", 30303);
+    final InetSocketAddress peerIpv6 =
+        new InetSocketAddress(Inet6Address.getByName("2001:db8::1"), 30304);
+    final NodeRecord dualStackPeer = createDualStackPeerRecord(peerIpv4, peerIpv6);
+
+    final NodeSession session = lookupSessionForOutgoingMessage(dualStackPeer, handler);
+
+    assertThat(session).isNotNull();
+    assertThat(session.getRemoteAddress()).isEqualTo(peerIpv4);
+  }
+
+  @Test
   void shouldNotGetASessionWhenNoAddressIsAvailable() {
     final NodeRecord nodeRecord =
         new NodeRecordFactory(new SimpleIdentitySchemaInterpreter())
@@ -149,5 +195,25 @@ class NodeSessionManagerTest {
     handler.handle(envelope);
 
     return envelope.get(Field.SESSION);
+  }
+
+  private NodeSession lookupSessionForOutgoingMessage(
+      final NodeRecord peerRecord, final NodeSessionManager handlerToUse) {
+    final Envelope envelope = new Envelope();
+    envelope.put(Field.SESSION_LOOKUP, new SessionLookup(NODE_ID));
+    envelope.put(Field.NODE, peerRecord);
+    handlerToUse.handle(envelope);
+
+    return envelope.get(Field.SESSION);
+  }
+
+  private NodeRecord createDualStackPeerRecord(
+      final InetSocketAddress ipv4, final InetSocketAddress ipv6) {
+    return SimpleIdentitySchemaInterpreter.createNodeRecord(
+        NODE_ID,
+        new EnrField(EnrField.IP_V4, Bytes.wrap(ipv4.getAddress().getAddress())),
+        new EnrField(EnrField.UDP, ipv4.getPort()),
+        new EnrField(EnrField.IP_V6, Bytes.wrap(ipv6.getAddress().getAddress())),
+        new EnrField(EnrField.UDP_V6, ipv6.getPort()));
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/NodeSessionManagerTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.Executors;
@@ -140,7 +139,8 @@ class NodeSessionManagerTest {
         new InetSocketAddress(Inet6Address.getByName("2001:db8::1"), 30304);
     final NodeRecord dualStackPeer = createDualStackPeerRecord(peerIpv4, peerIpv6);
 
-    final NodeSession session = lookupSessionForOutgoingMessage(dualStackPeer, ipv6BindAvailableHandler);
+    final NodeSession session =
+        lookupSessionForOutgoingMessage(dualStackPeer, ipv6BindAvailableHandler);
 
     assertThat(session).isNotNull();
     assertThat(session.getRemoteAddress().getAddress()).isInstanceOf(Inet6Address.class);


### PR DESCRIPTION
## Summary

When a node binds an IPv6 discovery socket but its home record has not (yet) advertised `ip6`, `NodeSessionManager.getRemoteSocketAddress` would still pick the peer's IPv4 address for outbound dials. This makes IPv6 external-address auto-discovery impossible to bootstrap: peers can only PONG with our IPv6 source address if we PING them over IPv6 first, but we never do.

### Current logic

```java
if (homeUdpAddress.isPresent() && homeUdp6Address.isPresent()) {
    return nodeRecord.getUdp6Address().or(nodeRecord::getUdpAddress);
} else if (homeUdp6Address.isPresent()) {
    return nodeRecord.getUdp6Address();
} else {
    return nodeRecord.getUdpAddress();   // ← IPv4-only home record falls here
}
```

A dual-stack-bound node whose home record advertises only `ip` always dials IPv4 → peers PONG with our IPv4 recipientIp → `DefaultExternalAddressSelector` accumulates only IPv4 votes → MIN_CONFIRMATIONS=2 for IPv6 is never reached → the `NewAddressHandler` never fires for IPv6 → our home record never gains `ip6`. Chicken-and-egg.

### Fix

Thread a `boolean ipv6BindAvailable` from `DiscoveryManagerImpl` (derived from the bound `discoveryServers` list) into `NodeSessionManager`. When set, prefer the peer's `ip6` — even if our home record has only `ip` — falling back to the peer's `ip` if the peer is IPv4-only.

```java
final boolean preferIpv6Outbound = homeUdp6Address.isPresent() || ipv6BindAvailable;
if (homeUdpAddress.isPresent() && preferIpv6Outbound) {
    return nodeRecord.getUdp6Address().or(nodeRecord::getUdpAddress);
} else if (preferIpv6Outbound) {
    return nodeRecord.getUdp6Address();
} else {
    return nodeRecord.getUdpAddress();
}
```

Together with the per-family selector change in #202 (already merged on master) this lets a dual-stack-bound node populate its own `ip6`/`udp6`/`tcp6` ENR fields via peer consensus, fixing the auto-discovery bootstrap that downstream feature [besu-eth/besu#9874](https://github.com/besu-eth/besu/issues/9874) depends on.

### Why this hasn't surfaced before

The discovery library currently has two consumers, Teku and Besu, and they populate the home node's ENR with different timing:

- **Teku** populates the local ENR's `ip6` field at startup, either from `--p2p-advertised-ip` or from local-interface resolution (`NetworkConfig.getLocalAddress(IP_V6)`), before discovery starts. So `homeUdp6Address.isPresent()` is true whenever Teku has an IPv6 socket bound — the existing v6-preference path is already taken, and Teku has never observed the bug. See Teku commit [`bf348b7271`](https://github.com/Consensys/teku/commit/bf348b7271) ("Fix ipv6 discovery — always populate the initial ENR with the resolved listen addresses").
- **Besu**'s in-flight peer-consensus IPv6 auto-discovery ([besu-eth/besu#10416](https://github.com/besu-eth/besu/pull/10416), for [besu-eth/besu#9874](https://github.com/besu-eth/besu/issues/9874)) intentionally leaves `ip6` empty at boot and relies on the external-address selector to populate it from peer PONGs. This places the home record in exactly the state the current dialer refuses to handle: socket bound, ENR empty.

This PR is therefore a **no-op for Teku** — when the home record already advertises `ip6`, `homeUdp6Address.isPresent()` is true and dominates the new OR, so dial selection is byte-for-byte identical to today. For Besu it closes the bootstrap loop together with the per-family selector change already on master in #202.

### Verified

- Compiles clean.
- Local Docker end-to-end against a Besu build pinned to this snapshot: after ~75s and 2 connected peers, the target node's ENR transitions from IPv4-only `seq=1` to dual-stack `seq=2` with the correct `ip6`/`udp6`/`tcp6` values. Without this fix, `seq` stays at 1 with no IPv6 fields.
- Added two unit tests in `NodeSessionManagerTest`:
  - `shouldDialPeerOverIpv6WhenIpv6BindAvailableEvenIfHomeRecordIsIpv4Only` — the bootstrap case.
  - `shouldDialPeerOverIpv4WhenIpv6BindNotAvailableAndHomeRecordIsIpv4Only` — regression of the existing default behaviour.

### Behaviour matrix

| Home record | `ipv6BindAvailable` | Peer ENR | Resulting dial |
|---|---|---|---|
| IPv4 only | false (today) | dual-stack | peer IPv4 (unchanged) |
| IPv4 only | **true (new)** | dual-stack | peer IPv6 |
| IPv4 only | **true (new)** | IPv4-only | peer IPv4 (graceful fallback) |
| dual-stack | any | dual-stack | peer IPv6 (unchanged) |
| IPv6 only | any | dual-stack | peer IPv6 (unchanged) |

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [x] New unit tests cover both new and regression behaviours
- [x] Verified end-to-end with a Besu build pinned to this snapshot
- [x] CI on this PR
