### PR TITLE
Fix concurrent local ENR custom field updates

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
@@ -92,9 +92,12 @@ public class LocalNodeRecordStore {
   }
 
   public void onCustomFieldValueChanged(final String fieldName, final Bytes value) {
-    NodeRecord oldRecord = this.latestRecord.get();
-    NodeRecord newRecord = oldRecord.withUpdatedCustomField(fieldName, value, signer);
-    this.latestRecord.set(newRecord);
+    NodeRecord oldRecord;
+    NodeRecord newRecord;
+    do {
+      oldRecord = this.latestRecord.get();
+      newRecord = oldRecord.withUpdatedCustomField(fieldName, value, signer);
+    } while (!latestRecord.compareAndSet(oldRecord, newRecord));
     recordListener.recordUpdated(oldRecord, newRecord);
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
@@ -7,14 +7,13 @@ package org.ethereum.beacon.discovery.storage;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.crypto.Signer;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 
 public class LocalNodeRecordStore {
 
-  private final AtomicReference<NodeRecord> latestRecord;
+  private NodeRecord latestRecord;
   private final Signer signer;
   private final NodeRecordListener recordListener;
   private final NewAddressHandler newAddressHandler;
@@ -24,27 +23,21 @@ public class LocalNodeRecordStore {
       final Signer signer,
       final NodeRecordListener recordListener,
       final NewAddressHandler newAddressHandler) {
-    this.latestRecord = new AtomicReference<>(record);
+    this.latestRecord = record;
     this.signer = signer;
     this.recordListener = recordListener;
     this.newAddressHandler = newAddressHandler;
   }
 
-  public NodeRecord getLocalNodeRecord() {
-    return latestRecord.get();
+  public synchronized NodeRecord getLocalNodeRecord() {
+    return latestRecord;
   }
 
-  public void onSocketAddressChanged(final InetSocketAddress newAddress) {
-    NodeRecord oldRecord = this.latestRecord.get();
+  public synchronized void onSocketAddressChanged(final InetSocketAddress newAddress) {
+    NodeRecord oldRecord = this.latestRecord;
     newAddressHandler
         .newAddress(oldRecord, newAddress)
-        .ifPresent(
-            record -> {
-              this.latestRecord.set(record);
-              if (!record.equals(oldRecord)) {
-                recordListener.recordUpdated(oldRecord, record);
-              }
-            });
+        .ifPresent(record -> updateLocalNodeRecord(oldRecord, record, false));
   }
 
   /**
@@ -58,46 +51,45 @@ public class LocalNodeRecordStore {
    * <p>If the current ENR port is not 0, this method is a no-op.
    *
    * <p>In dual-stack configurations both the IPv4 and IPv6 servers may call this method
-   * concurrently. A CAS retry loop ensures that each update is applied to the latest record so
-   * neither family's port is lost.
+   * concurrently. Updates are serialized across all local ENR writer paths so neither family's port
+   * is lost and listener notifications remain ordered.
    *
    * @param boundAddress the address returned by the server after binding (bind IP + actual port)
    */
-  public void onBoundPortResolved(final InetSocketAddress boundAddress) {
+  public synchronized void onBoundPortResolved(final InetSocketAddress boundAddress) {
     final boolean isIpv6 = boundAddress.getAddress() instanceof Inet6Address;
-    NodeRecord current;
-    NodeRecord updated;
-    do {
-      current = latestRecord.get();
-      final Optional<InetSocketAddress> currentUdpAddr =
-          isIpv6 ? current.getUdp6Address() : current.getUdpAddress();
-      if (currentUdpAddr.isEmpty() || currentUdpAddr.get().getPort() != 0) {
-        return;
-      }
-      final InetSocketAddress newUdpAddress =
-          new InetSocketAddress(currentUdpAddr.get().getAddress(), boundAddress.getPort());
-      final Optional<Integer> existingTcpPort =
-          isIpv6
-              ? current.getTcp6Address().map(InetSocketAddress::getPort)
-              : current.getTcpAddress().map(InetSocketAddress::getPort);
-      final Optional<Integer> existingQuicPort =
-          isIpv6
-              ? current.getQuic6Address().map(InetSocketAddress::getPort)
-              : current.getQuicAddress().map(InetSocketAddress::getPort);
-      updated = current.withNewAddress(newUdpAddress, existingTcpPort, existingQuicPort, signer);
-    } while (!latestRecord.compareAndSet(current, updated));
-    if (!updated.equals(current)) {
-      recordListener.recordUpdated(current, updated);
+    final NodeRecord current = latestRecord;
+    final Optional<InetSocketAddress> currentUdpAddr =
+        isIpv6 ? current.getUdp6Address() : current.getUdpAddress();
+    if (currentUdpAddr.isEmpty() || currentUdpAddr.get().getPort() != 0) {
+      return;
     }
+    final InetSocketAddress newUdpAddress =
+        new InetSocketAddress(currentUdpAddr.get().getAddress(), boundAddress.getPort());
+    final Optional<Integer> existingTcpPort =
+        isIpv6
+            ? current.getTcp6Address().map(InetSocketAddress::getPort)
+            : current.getTcpAddress().map(InetSocketAddress::getPort);
+    final Optional<Integer> existingQuicPort =
+        isIpv6
+            ? current.getQuic6Address().map(InetSocketAddress::getPort)
+            : current.getQuicAddress().map(InetSocketAddress::getPort);
+    final NodeRecord updated =
+        current.withNewAddress(newUdpAddress, existingTcpPort, existingQuicPort, signer);
+    updateLocalNodeRecord(current, updated, false);
   }
 
-  public void onCustomFieldValueChanged(final String fieldName, final Bytes value) {
-    NodeRecord oldRecord;
-    NodeRecord newRecord;
-    do {
-      oldRecord = this.latestRecord.get();
-      newRecord = oldRecord.withUpdatedCustomField(fieldName, value, signer);
-    } while (!latestRecord.compareAndSet(oldRecord, newRecord));
-    recordListener.recordUpdated(oldRecord, newRecord);
+  public synchronized void onCustomFieldValueChanged(final String fieldName, final Bytes value) {
+    final NodeRecord oldRecord = this.latestRecord;
+    final NodeRecord newRecord = oldRecord.withUpdatedCustomField(fieldName, value, signer);
+    updateLocalNodeRecord(oldRecord, newRecord, true);
+  }
+
+  private void updateLocalNodeRecord(
+      final NodeRecord oldRecord, final NodeRecord newRecord, final boolean notifyWhenUnchanged) {
+    this.latestRecord = newRecord;
+    if (notifyWhenUnchanged || !newRecord.equals(oldRecord)) {
+      recordListener.recordUpdated(oldRecord, newRecord);
+    }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
+++ b/src/main/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStore.java
@@ -13,7 +13,7 @@ import org.ethereum.beacon.discovery.schema.NodeRecord;
 
 public class LocalNodeRecordStore {
 
-  private NodeRecord latestRecord;
+  private volatile NodeRecord latestRecord;
   private final Signer signer;
   private final NodeRecordListener recordListener;
   private final NewAddressHandler newAddressHandler;
@@ -29,7 +29,7 @@ public class LocalNodeRecordStore {
     this.newAddressHandler = newAddressHandler;
   }
 
-  public synchronized NodeRecord getLocalNodeRecord() {
+  public NodeRecord getLocalNodeRecord() {
     return latestRecord;
   }
 
@@ -37,7 +37,7 @@ public class LocalNodeRecordStore {
     NodeRecord oldRecord = this.latestRecord;
     newAddressHandler
         .newAddress(oldRecord, newAddress)
-        .ifPresent(record -> updateLocalNodeRecord(oldRecord, record, false));
+        .ifPresent(record -> updateLocalNodeRecord(oldRecord, record));
   }
 
   /**
@@ -76,19 +76,18 @@ public class LocalNodeRecordStore {
             : current.getQuicAddress().map(InetSocketAddress::getPort);
     final NodeRecord updated =
         current.withNewAddress(newUdpAddress, existingTcpPort, existingQuicPort, signer);
-    updateLocalNodeRecord(current, updated, false);
+    updateLocalNodeRecord(current, updated);
   }
 
   public synchronized void onCustomFieldValueChanged(final String fieldName, final Bytes value) {
     final NodeRecord oldRecord = this.latestRecord;
     final NodeRecord newRecord = oldRecord.withUpdatedCustomField(fieldName, value, signer);
-    updateLocalNodeRecord(oldRecord, newRecord, true);
+    updateLocalNodeRecord(oldRecord, newRecord);
   }
 
-  private void updateLocalNodeRecord(
-      final NodeRecord oldRecord, final NodeRecord newRecord, final boolean notifyWhenUnchanged) {
+  private void updateLocalNodeRecord(final NodeRecord oldRecord, final NodeRecord newRecord) {
     this.latestRecord = newRecord;
-    if (notifyWhenUnchanged || !newRecord.equals(oldRecord)) {
+    if (!newRecord.equals(oldRecord)) {
       recordListener.recordUpdated(oldRecord, newRecord);
     }
   }

--- a/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
@@ -12,7 +12,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.crypto.DefaultSigner;
@@ -164,5 +166,75 @@ public class LocalNodeRecordStoreTest {
     assertThat(finalRecord.getUdp6Address().orElseThrow().getPort())
         .as("IPv6 UDP port must be resolved")
         .isEqualTo(30304);
+  }
+
+  /**
+   * Reproduces the lost update from issue #190. Both threads build their replacement record from
+   * the same original ENR, so a plain set can let the second write overwrite the first write's
+   * custom field.
+   */
+  @Test
+  void onCustomFieldValueChangedHandlesConcurrentUpdates() throws Exception {
+    final Signer signer =
+        new BarrierSigner(new DefaultSigner(Functions.randomKeyPair().secretKey()));
+    final NodeRecord nodeRecord =
+        new NodeRecordBuilder().signer(signer).address("127.0.0.1", 30303).build();
+
+    final LocalNodeRecordStore recordStore =
+        new LocalNodeRecordStore(nodeRecord, signer, (o, n) -> {}, ADDRESS_UPDATER);
+
+    ((BarrierSigner) signer).enableBlocking();
+
+    final Thread fieldAThread =
+        new Thread(
+            () -> recordStore.onCustomFieldValueChanged("fieldA", Bytes.fromHexString("0xaaaa")));
+    final Thread fieldBThread =
+        new Thread(
+            () -> recordStore.onCustomFieldValueChanged("fieldB", Bytes.fromHexString("0xbbbb")));
+
+    fieldAThread.start();
+    fieldBThread.start();
+    fieldAThread.join();
+    fieldBThread.join();
+
+    final NodeRecord finalRecord = recordStore.getLocalNodeRecord();
+    assertThat(finalRecord.get("fieldA")).isEqualTo(Bytes.fromHexString("0xaaaa"));
+    assertThat(finalRecord.get("fieldB")).isEqualTo(Bytes.fromHexString("0xbbbb"));
+  }
+
+  private static class BarrierSigner implements Signer {
+    private final Signer delegate;
+    private final CyclicBarrier barrier = new CyclicBarrier(2);
+    private final AtomicInteger signaturesToBlock = new AtomicInteger();
+
+    private BarrierSigner(final Signer delegate) {
+      this.delegate = delegate;
+    }
+
+    private void enableBlocking() {
+      signaturesToBlock.set(2);
+    }
+
+    @Override
+    public Bytes sign(final Bytes32 messageHash) {
+      if (signaturesToBlock.getAndUpdate(value -> Math.max(0, value - 1)) > 0) {
+        try {
+          barrier.await();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return delegate.sign(messageHash);
+    }
+
+    @Override
+    public Bytes deriveECDHKeyAgreement(final Bytes destPubKey) {
+      return delegate.deriveECDHKeyAgreement(destPubKey);
+    }
+
+    @Override
+    public Bytes deriveCompressedPublicKeyFromPrivate() {
+      return delegate.deriveCompressedPublicKeyFromPrivate();
+    }
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/storage/LocalNodeRecordStoreTest.java
@@ -11,10 +11,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.ethereum.beacon.discovery.SimpleIdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.crypto.DefaultSigner;
@@ -26,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 public class LocalNodeRecordStoreTest {
 
+  private record Update(NodeRecord oldRecord, NodeRecord newRecord) {}
+
   @Test
   void testListenerIsCalled() {
     NodeRecord nodeRecord1 =
@@ -35,15 +41,6 @@ public class LocalNodeRecordStoreTest {
         SimpleIdentitySchemaInterpreter.createNodeRecord(
             Bytes.ofUnsignedInt(2), new InetSocketAddress("127.0.0.1", 9002));
 
-    class Update {
-      NodeRecord oldRec;
-      NodeRecord newRec;
-
-      public Update(NodeRecord oldRec, NodeRecord newRec) {
-        this.oldRec = oldRec;
-        this.newRec = newRec;
-      }
-    }
     List<Update> listenerCalls = new ArrayList<>();
     LocalNodeRecordStore recordStore =
         new LocalNodeRecordStore(
@@ -53,8 +50,8 @@ public class LocalNodeRecordStoreTest {
     recordStore.onSocketAddressChanged(nodeRecord2.getUdpAddress().orElseThrow());
 
     assertThat(listenerCalls).hasSize(1);
-    assertThat(listenerCalls.get(0).oldRec).isEqualTo(nodeRecord1);
-    assertThat(listenerCalls.get(0).newRec.getUdpAddress())
+    assertThat(listenerCalls.get(0).oldRecord()).isEqualTo(nodeRecord1);
+    assertThat(listenerCalls.get(0).newRecord().getUdpAddress())
         .contains(nodeRecord2.getUdpAddress().orElseThrow());
     assertThat(recordStore.getLocalNodeRecord().getUdpAddress().orElseThrow())
         .isEqualTo(nodeRecord2.getUdpAddress().get());
@@ -62,8 +59,8 @@ public class LocalNodeRecordStoreTest {
     recordStore.onCustomFieldValueChanged("fieldName", Bytes.fromHexString("0x112233"));
 
     assertThat(listenerCalls).hasSize(2);
-    assertThat(listenerCalls.get(1).oldRec).isEqualTo(listenerCalls.get(0).newRec);
-    assertThat(listenerCalls.get(1).newRec.get("fieldName"))
+    assertThat(listenerCalls.get(1).oldRecord()).isEqualTo(listenerCalls.get(0).newRecord());
+    assertThat(listenerCalls.get(1).newRecord().get("fieldName"))
         .isEqualTo(Bytes.fromHexString("0x112233"));
   }
 
@@ -106,8 +103,8 @@ public class LocalNodeRecordStoreTest {
 
   /**
    * Verifies that concurrent IPv4 and IPv6 {@code onBoundPortResolved} calls in a dual-stack
-   * configuration do not lose either port update. Without the CAS retry loop, the second write
-   * would overwrite the first's update leaving one port still at 0.
+   * configuration do not lose either port update. Without serialized writes, the second write would
+   * overwrite the first's update leaving one port still at 0.
    */
   @Test
   void onBoundPortResolvedHandlesConcurrentDualStackUpdates() throws Exception {
@@ -122,42 +119,20 @@ public class LocalNodeRecordStoreTest {
             .address("::1", 0) // udp6=0
             .build();
 
-    final List<NodeRecord> updates = Collections.synchronizedList(new ArrayList<>());
+    final List<Update> updates = Collections.synchronizedList(new ArrayList<>());
     final LocalNodeRecordStore recordStore =
         new LocalNodeRecordStore(
-            nodeRecord, signer, (o, n) -> updates.add(n), (rec, addr) -> Optional.empty());
+            nodeRecord,
+            signer,
+            (o, n) -> updates.add(new Update(o, n)),
+            (rec, addr) -> Optional.empty());
 
-    // Force both threads to call onBoundPortResolved at exactly the same time.
-    final CyclicBarrier barrier = new CyclicBarrier(2);
     final InetSocketAddress ipv4Bound = new InetSocketAddress("0.0.0.0", 30303);
     final InetSocketAddress ipv6Bound = new InetSocketAddress("::1", 30304);
 
-    final Thread ipv4Thread =
-        new Thread(
-            () -> {
-              try {
-                barrier.await();
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-              recordStore.onBoundPortResolved(ipv4Bound);
-            });
-
-    final Thread ipv6Thread =
-        new Thread(
-            () -> {
-              try {
-                barrier.await();
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-              recordStore.onBoundPortResolved(ipv6Bound);
-            });
-
-    ipv4Thread.start();
-    ipv6Thread.start();
-    ipv4Thread.join();
-    ipv6Thread.join();
+    runConcurrently(
+        () -> recordStore.onBoundPortResolved(ipv4Bound),
+        () -> recordStore.onBoundPortResolved(ipv6Bound));
 
     final NodeRecord finalRecord = recordStore.getLocalNodeRecord();
     assertThat(finalRecord.getUdpAddress().orElseThrow().getPort())
@@ -166,75 +141,112 @@ public class LocalNodeRecordStoreTest {
     assertThat(finalRecord.getUdp6Address().orElseThrow().getPort())
         .as("IPv6 UDP port must be resolved")
         .isEqualTo(30304);
+    assertThat(updates).hasSize(2);
+    assertChainedUpdates(updates, nodeRecord, finalRecord);
   }
 
   /**
-   * Reproduces the lost update from issue #190. Both threads build their replacement record from
-   * the same original ENR, so a plain set can let the second write overwrite the first write's
-   * custom field.
+   * Verifies that concurrent custom field updates from issue #190 do not lose either field and keep
+   * listener notifications chained.
    */
   @Test
   void onCustomFieldValueChangedHandlesConcurrentUpdates() throws Exception {
-    final Signer signer =
-        new BarrierSigner(new DefaultSigner(Functions.randomKeyPair().secretKey()));
+    final Signer signer = new DefaultSigner(Functions.randomKeyPair().secretKey());
     final NodeRecord nodeRecord =
         new NodeRecordBuilder().signer(signer).address("127.0.0.1", 30303).build();
 
+    final List<Update> updates = Collections.synchronizedList(new ArrayList<>());
     final LocalNodeRecordStore recordStore =
-        new LocalNodeRecordStore(nodeRecord, signer, (o, n) -> {}, ADDRESS_UPDATER);
+        new LocalNodeRecordStore(
+            nodeRecord, signer, (o, n) -> updates.add(new Update(o, n)), ADDRESS_UPDATER);
 
-    ((BarrierSigner) signer).enableBlocking();
-
-    final Thread fieldAThread =
-        new Thread(
-            () -> recordStore.onCustomFieldValueChanged("fieldA", Bytes.fromHexString("0xaaaa")));
-    final Thread fieldBThread =
-        new Thread(
-            () -> recordStore.onCustomFieldValueChanged("fieldB", Bytes.fromHexString("0xbbbb")));
-
-    fieldAThread.start();
-    fieldBThread.start();
-    fieldAThread.join();
-    fieldBThread.join();
+    runConcurrently(
+        () -> recordStore.onCustomFieldValueChanged("fieldA", Bytes.fromHexString("0xaaaa")),
+        () -> recordStore.onCustomFieldValueChanged("fieldB", Bytes.fromHexString("0xbbbb")));
 
     final NodeRecord finalRecord = recordStore.getLocalNodeRecord();
     assertThat(finalRecord.get("fieldA")).isEqualTo(Bytes.fromHexString("0xaaaa"));
     assertThat(finalRecord.get("fieldB")).isEqualTo(Bytes.fromHexString("0xbbbb"));
+    assertThat(updates).hasSize(2);
+    assertChainedUpdates(updates, nodeRecord, finalRecord);
   }
 
-  private static class BarrierSigner implements Signer {
-    private final Signer delegate;
-    private final CyclicBarrier barrier = new CyclicBarrier(2);
-    private final AtomicInteger signaturesToBlock = new AtomicInteger();
+  @Test
+  void onSocketAddressChangedAndCustomFieldValueChangedHandleConcurrentUpdates() throws Exception {
+    final Signer signer = new DefaultSigner(Functions.randomKeyPair().secretKey());
+    final NodeRecord nodeRecord =
+        new NodeRecordBuilder().signer(signer).address("127.0.0.1", 30303).build();
+    final List<Update> updates = Collections.synchronizedList(new ArrayList<>());
+    final LocalNodeRecordStore recordStore =
+        new LocalNodeRecordStore(
+            nodeRecord,
+            signer,
+            (o, n) -> updates.add(new Update(o, n)),
+            (oldRecord, newAddress) ->
+                Optional.of(
+                    oldRecord.withNewAddress(
+                        newAddress, Optional.empty(), Optional.empty(), signer)));
+    final InetSocketAddress newAddress = new InetSocketAddress("127.0.0.2", 30304);
 
-    private BarrierSigner(final Signer delegate) {
-      this.delegate = delegate;
-    }
+    runConcurrently(
+        () -> recordStore.onSocketAddressChanged(newAddress),
+        () -> recordStore.onCustomFieldValueChanged("fieldA", Bytes.fromHexString("0xaaaa")));
 
-    private void enableBlocking() {
-      signaturesToBlock.set(2);
-    }
+    final NodeRecord finalRecord = recordStore.getLocalNodeRecord();
+    final InetSocketAddress finalAddress = finalRecord.getUdpAddress().orElseThrow();
+    assertThat(finalAddress.getAddress().getHostAddress()).isEqualTo("127.0.0.2");
+    assertThat(finalAddress.getPort()).isEqualTo(30304);
+    assertThat(finalRecord.get("fieldA")).isEqualTo(Bytes.fromHexString("0xaaaa"));
+    assertThat(updates).hasSize(2);
+    assertChainedUpdates(updates, nodeRecord, finalRecord);
+  }
 
-    @Override
-    public Bytes sign(final Bytes32 messageHash) {
-      if (signaturesToBlock.getAndUpdate(value -> Math.max(0, value - 1)) > 0) {
-        try {
-          barrier.await();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
+  private static void runConcurrently(final CheckedRunnable... tasks) throws Exception {
+    final ExecutorService executor = Executors.newFixedThreadPool(tasks.length);
+    final CyclicBarrier startBarrier = new CyclicBarrier(tasks.length);
+    try {
+      final List<Future<?>> futures = new ArrayList<>();
+      for (CheckedRunnable task : tasks) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  awaitBarrier(startBarrier);
+                  task.run();
+                  return null;
+                }));
       }
-      return delegate.sign(messageHash);
+      for (Future<?> future : futures) {
+        future.get(5, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
     }
+  }
 
-    @Override
-    public Bytes deriveECDHKeyAgreement(final Bytes destPubKey) {
-      return delegate.deriveECDHKeyAgreement(destPubKey);
+  private static void awaitBarrier(final CyclicBarrier barrier) {
+    try {
+      barrier.await(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (BrokenBarrierException | TimeoutException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @Override
-    public Bytes deriveCompressedPublicKeyFromPrivate() {
-      return delegate.deriveCompressedPublicKeyFromPrivate();
+  private static void assertChainedUpdates(
+      final List<Update> updates, final NodeRecord initialRecord, final NodeRecord finalRecord) {
+    NodeRecord expectedOldRecord = initialRecord;
+    for (Update update : updates) {
+      assertThat(update.oldRecord()).isEqualTo(expectedOldRecord);
+      expectedOldRecord = update.newRecord();
     }
+    assertThat(expectedOldRecord).isEqualTo(finalRecord);
+  }
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+    void run() throws Exception;
   }
 }


### PR DESCRIPTION
## Summary
- serialize `LocalNodeRecordStore` writer paths so local ENR updates are applied from the latest record and listener callbacks remain ordered
- keep writer methods synchronized while making `latestRecord` volatile so `getLocalNodeRecord()` can read without taking the lock
- expand concurrency regression coverage for custom-field updates, bound-port resolution, and mixed socket-address/custom-field updates
- replace raw thread joins with timeout-based executor helpers and assert listener update chains

Fixes #190

## Tests
- `./gradlew spotlessApply test --tests org.ethereum.beacon.discovery.storage.LocalNodeRecordStoreTest`
