### PR TITLE
fix: track multiple pending WHOAREYOU challenges during handshake

### DIFF
--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/HandshakeMessagePacketHandler.java
@@ -6,6 +6,7 @@ package org.ethereum.beacon.discovery.pipeline.handler;
 
 import static org.ethereum.beacon.discovery.schema.NodeSession.SessionState.AUTHENTICATED;
 
+import java.util.Collection;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,24 +70,12 @@ public class HandshakeMessagePacketHandler extends AbstractSkippingEnvelopeHandl
     NodeSession session = envelope.get(Field.SESSION);
     try {
 
-      if (session.getWhoAreYouChallenge().isEmpty()) {
+      Collection<Bytes> pendingChallenges = session.getPendingWhoAreYouChallenges();
+      if (pendingChallenges.isEmpty()) {
         LOG.trace(String.format("Outbound WhoAreYou challenge not found for session %s", session));
         markHandshakeAsFailed(envelope, session);
         return;
       }
-      Bytes whoAreYouChallenge = session.getWhoAreYouChallenge().get();
-
-      Bytes ephemeralPubKeyCompressed = packet.getHeader().getAuthData().getEphemeralPubKey();
-      Functions.HKDFKeys keys =
-          Functions.hkdfExpand(
-              session.getNodeId(),
-              session.getHomeNodeId(),
-              session.getSigner(),
-              ephemeralPubKeyCompressed,
-              whoAreYouChallenge);
-      // Swap keys because we are not initiator, other side is
-      session.setInitiatorKey(keys.getRecipientKey());
-      session.setRecipientKey(keys.getInitiatorKey());
 
       Optional<NodeRecord> enr = packet.getHeader().getAuthData().getNodeRecord(nodeRecordFactory);
       if (!enr.map(NodeRecord::isValid).orElse(true)) {
@@ -116,17 +105,23 @@ public class HandshakeMessagePacketHandler extends AbstractSkippingEnvelopeHandl
         return;
       }
       NodeRecord nodeRecord = nodeRecordMaybe.get();
+      Bytes remotePubKey = (Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1);
 
-      boolean idNonceVerifyResult =
-          packet
-              .getHeader()
-              .getAuthData()
-              .verify(
-                  whoAreYouChallenge,
-                  session.getHomeNodeId(),
-                  (Bytes) nodeRecord.get(EnrField.PKEY_SECP256K1));
+      // The handshake packet does not directly identify which WHOAREYOU it answers, so we try
+      // each pending challenge and accept the one whose ID signature verifies.
+      Bytes ephemeralPubKeyCompressed = packet.getHeader().getAuthData().getEphemeralPubKey();
+      Bytes matchedChallenge = null;
+      for (Bytes candidate : pendingChallenges) {
+        if (packet
+            .getHeader()
+            .getAuthData()
+            .verify(candidate, session.getHomeNodeId(), remotePubKey)) {
+          matchedChallenge = candidate;
+          break;
+        }
+      }
 
-      if (!idNonceVerifyResult) {
+      if (matchedChallenge == null) {
         LOG.trace(
             String.format(
                 "ID signature not valid for message [%s] from node %s in status %s",
@@ -135,12 +130,24 @@ public class HandshakeMessagePacketHandler extends AbstractSkippingEnvelopeHandl
         return;
       }
 
+      Functions.HKDFKeys keys =
+          Functions.hkdfExpand(
+              session.getNodeId(),
+              session.getHomeNodeId(),
+              session.getSigner(),
+              ephemeralPubKeyCompressed,
+              matchedChallenge);
+      // Swap keys because we are not initiator, other side is
+      session.setInitiatorKey(keys.getRecipientKey());
+      session.setRecipientKey(keys.getInitiatorKey());
+
       Bytes16 maskingIV = envelope.get(Field.MASKING_IV);
       V5Message message =
           packet.decryptMessage(maskingIV, session.getRecipientKey(), nodeRecordFactory);
       envelope.put(Field.MESSAGE, message);
 
       session.setState(AUTHENTICATED);
+      session.clearPendingWhoAreYouChallenges();
       envelope.remove(Field.PACKET_HANDSHAKE);
       enr.ifPresent(session::onNodeRecordReceived);
       NextTaskHandler.tryToSendAwaitTaskIfAny(session, outgoingPipeline, scheduler);

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandler.java
@@ -45,14 +45,13 @@ public class UnauthorizedMessagePacketHandler extends AbstractSkippingEnvelopeHa
     OrdinaryMessagePacket unknownPacket = envelope.get(Field.UNAUTHORIZED_PACKET_MESSAGE);
     Bytes12 msgNonce = unknownPacket.getHeader().getStaticHeader().getNonce();
 
-    // If already awaiting handshake completion, resend the original WHOAREYOU for retransmissions
-    // of the same packet (same nonce). For a new nonce, fall through and issue a fresh WHOAREYOU
-    // so the initiator's nonce check can pass.
-    if (session.getState() == SessionState.WHOAREYOU_SENT) {
-      if (session.getPendingWhoAreYouNonce().map(msgNonce::equals).orElse(false)) {
-        session.resendOutgoingWhoAreYou();
-        return;
-      }
+    // If we have already issued a WHOAREYOU for this exact ordinary packet nonce, resend that
+    // same challenge — the initiator may have already signed against it. For any other nonce,
+    // fall through and issue a fresh WHOAREYOU; previous in-flight challenges remain queued so a
+    // delayed handshake signed against one of them can still be validated.
+    if (session.hasPendingWhoAreYouForNonce(msgNonce)) {
+      session.resendOutgoingWhoAreYouFor(msgNonce);
+      return;
     }
 
     try {

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -87,7 +87,7 @@ public class NodeSession {
   // a busy peer) from forcing unbounded growth.
   private final Map<Bytes12, PendingWhoAreYou> pendingWhoAreYou =
       Collections.synchronizedMap(
-          new LinkedHashMap<>(MAX_PENDING_WHOAREYOU + 1, 1.0f, false) {
+          new LinkedHashMap<>(MAX_PENDING_WHOAREYOU + 1, 1.0f, true) {
             @Override
             protected boolean removeEldestEntry(final Map.Entry<Bytes12, PendingWhoAreYou> eldest) {
               return size() > MAX_PENDING_WHOAREYOU;

--- a/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
+++ b/src/main/java/org/ethereum/beacon/discovery/schema/NodeSession.java
@@ -10,7 +10,10 @@ import static org.ethereum.beacon.discovery.task.TaskStatus.SENT;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -18,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,6 +56,13 @@ public class NodeSession {
   private static final Logger LOG = LogManager.getLogger(NodeSession.class);
 
   public static final int REQUEST_ID_SIZE = 8;
+
+  /**
+   * Maximum number of in-flight WHOAREYOU challenges retained per session. Bounds memory when an
+   * initiator sends many ordinary packets before completing the handshake.
+   */
+  @VisibleForTesting static final int MAX_PENDING_WHOAREYOU = 5;
+
   private final Bytes32 homeNodeId;
   private final LocalNodeRecordStore localNodeRecordStore;
   private final NodeSessionManager nodeSessionManager;
@@ -68,8 +79,21 @@ public class NodeSession {
   private final ExpirationScheduler<Bytes> requestExpirationScheduler;
   private final Signer signer;
   private Optional<InetSocketAddress> reportedExternalAddress = Optional.empty();
-  private Optional<Bytes> whoAreYouChallenge = Optional.empty();
-  private Optional<WhoAreYouPacket> pendingWhoAreYouPacket = Optional.empty();
+
+  // Pending WHOAREYOU challenges keyed by the ordinary packet nonce that caused each challenge.
+  // The discv5 wire spec requires the WHOAREYOU nonce to mirror the offending packet's nonce, and
+  // a handshake response signed against a prior challenge may arrive after a fresh challenge has
+  // been issued for a different ordinary packet. Keeping the set bounded prevents an attacker (or
+  // a busy peer) from forcing unbounded growth.
+  private final Map<Bytes12, PendingWhoAreYou> pendingWhoAreYou =
+      Collections.synchronizedMap(
+          new LinkedHashMap<>(MAX_PENDING_WHOAREYOU + 1, 1.0f, false) {
+            @Override
+            protected boolean removeEldestEntry(final Map.Entry<Bytes12, PendingWhoAreYou> eldest) {
+              return size() > MAX_PENDING_WHOAREYOU;
+            }
+          });
+
   private Optional<Bytes12> lastOutboundNonce = Optional.empty();
   private boolean active = true;
   private final Function<Random, Bytes12> nonceGenerator;
@@ -139,10 +163,6 @@ public class NodeSession {
     return remoteAddress;
   }
 
-  public Optional<Bytes> getWhoAreYouChallenge() {
-    return whoAreYouChallenge;
-  }
-
   public void sendOutgoingOrdinary(final V5Message message) {
     LOG.trace(() -> String.format("Sending outgoing message %s in session %s", message, this));
     Bytes16 maskingIV = generateMaskingIV();
@@ -166,31 +186,45 @@ public class NodeSession {
     LOG.trace(
         () -> String.format("Sending outgoing WhoAreYou message %s in session %s", packet, this));
     Bytes16 maskingIV = generateMaskingIV();
-    pendingWhoAreYouPacket = Optional.of(packet);
-    dispatchWhoAreYou(maskingIV, packet);
-  }
-
-  public synchronized Optional<Bytes12> getPendingWhoAreYouNonce() {
-    return pendingWhoAreYouPacket.map(p -> p.getHeader().getStaticHeader().getNonce());
-  }
-
-  public synchronized void resendOutgoingWhoAreYou() {
-    pendingWhoAreYouPacket.ifPresent(
-        packet -> {
-          LOG.trace(
-              () ->
-                  String.format(
-                      "Resending outgoing WhoAreYou message %s in session %s", packet, this));
-          // Reuse the original maskingIV so the stored challenge remains stable; the initiator
-          // may have already signed against it.
-          Bytes16 maskingIV = Bytes16.wrap(whoAreYouChallenge.orElseThrow().slice(0, 16));
-          sendOutgoing(maskingIV, packet);
-        });
-  }
-
-  private void dispatchWhoAreYou(final Bytes16 maskingIV, final WhoAreYouPacket packet) {
-    whoAreYouChallenge = Optional.of(Bytes.wrap(maskingIV, packet.getHeader().getBytes()));
+    Bytes challengeData = Bytes.wrap(maskingIV, packet.getHeader().getBytes());
+    Bytes12 msgNonce = packet.getHeader().getStaticHeader().getNonce();
+    pendingWhoAreYou.put(msgNonce, new PendingWhoAreYou(packet, maskingIV, challengeData));
     sendOutgoing(maskingIV, packet);
+  }
+
+  public boolean hasPendingWhoAreYouForNonce(final Bytes12 nonce) {
+    return pendingWhoAreYou.containsKey(nonce);
+  }
+
+  public void resendOutgoingWhoAreYouFor(final Bytes12 nonce) {
+    final PendingWhoAreYou pending = pendingWhoAreYou.get(nonce);
+    if (pending == null) {
+      return;
+    }
+    LOG.trace(
+        () ->
+            String.format(
+                "Resending outgoing WhoAreYou message %s in session %s", pending.packet(), this));
+    // Reuse the original maskingIV so the challenge bytes the initiator signed over remain
+    // identical.
+    sendOutgoing(pending.maskingIV(), pending.packet());
+  }
+
+  /**
+   * Returns the challenge data ({@code maskingIV || header bytes}) for every pending WHOAREYOU. The
+   * handshake handler attempts to match the incoming handshake against each candidate because the
+   * handshake packet does not directly identify which challenge it answers.
+   */
+  public Collection<Bytes> getPendingWhoAreYouChallenges() {
+    synchronized (pendingWhoAreYou) {
+      return pendingWhoAreYou.values().stream()
+          .map(PendingWhoAreYou::challengeData)
+          .collect(Collectors.toUnmodifiableList());
+    }
+  }
+
+  public void clearPendingWhoAreYouChallenges() {
+    pendingWhoAreYou.clear();
   }
 
   public void sendOutgoingHandshake(
@@ -252,7 +286,7 @@ public class NodeSession {
 
   private synchronized void resetHandshakeState() {
     if (state == SessionState.WHOAREYOU_SENT || state == SessionState.RANDOM_PACKET_SENT) {
-      pendingWhoAreYouPacket = Optional.empty();
+      pendingWhoAreYou.clear();
       setState(SessionState.INITIAL);
     }
   }
@@ -434,4 +468,6 @@ public class NodeSession {
     RANDOM_PACKET_SENT, // our node is initiator, we've sent random packet
     AUTHENTICATED
   }
+
+  private record PendingWhoAreYou(WhoAreYouPacket packet, Bytes16 maskingIV, Bytes challengeData) {}
 }

--- a/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/HandshakeHandlersTest.java
@@ -243,6 +243,139 @@ public class HandshakeHandlersTest {
     assertNotNull(envelopeAt2From1WithMessage.get(MESSAGE));
   }
 
+  /**
+   * A handshake signed against an earlier WHOAREYOU must still be accepted by the responder even
+   * when a fresh WHOAREYOU has been issued for a different ordinary packet nonce in the meantime.
+   */
+  @Test
+  public void responderAcceptsHandshakeForEarlierPendingWhoAreYou() throws Exception {
+    NodeInfo nodePair1 = TestUtil.generateUnverifiedNode(30303);
+    NodeRecord nodeRecord1 = nodePair1.getNodeRecord();
+    Signer signer1 = new DefaultSigner(nodePair1.getSecretKey());
+    NodeInfo nodePair2 = TestUtil.generateUnverifiedNode(30304);
+    NodeRecord nodeRecord2 = nodePair2.getNodeRecord();
+    Signer signer2 = new DefaultSigner(nodePair2.getSecretKey());
+
+    final LocalNodeRecordStore localNodeRecordStoreAt1 =
+        new LocalNodeRecordStore(
+            nodeRecord1, signer1, NodeRecordListener.NOOP, NewAddressHandler.NOOP);
+    KBuckets nodeBucketStorage1 =
+        new KBuckets(clock, localNodeRecordStoreAt1, new LivenessChecker(clock));
+    KBuckets nodeBucketStorage2 =
+        new KBuckets(
+            clock,
+            new LocalNodeRecordStore(
+                nodeRecord2, signer2, NodeRecordListener.NOOP, NewAddressHandler.NOOP),
+            new LivenessChecker(clock));
+
+    LinkedBlockingQueue<RawPacket> outgoing1Packets = new LinkedBlockingQueue<>();
+    final Consumer<NetworkParcel> outgoingMessages1to2 =
+        parcel -> outgoing1Packets.add(parcel.getPacket());
+    final ExpirationSchedulerFactory expirationSchedulerFactory =
+        new ExpirationSchedulerFactory(Executors.newSingleThreadScheduledExecutor());
+    final ExpirationScheduler<Bytes> requestExpirationScheduler =
+        expirationSchedulerFactory.create(60, TimeUnit.SECONDS);
+    NodeSession nodeSessionAt1For2 =
+        new NodeSession(
+            nodeRecord2.getNodeId(),
+            Optional.of(nodeRecord2),
+            nodePair2.getNodeRecord().getUdpAddress().orElseThrow(),
+            mock(NodeSessionManager.class),
+            localNodeRecordStoreAt1,
+            signer1,
+            nodeBucketStorage1,
+            outgoingMessages1to2,
+            rnd,
+            requestExpirationScheduler);
+    LinkedBlockingQueue<RawPacket> outgoing2Packets = new LinkedBlockingQueue<>();
+    final Consumer<NetworkParcel> outgoingMessages2to1 =
+        parcel -> outgoing2Packets.add(parcel.getPacket());
+    NodeSession nodeSessionAt2For1 =
+        new NodeSession(
+            nodeRecord1.getNodeId(),
+            Optional.of(nodeRecord1),
+            nodeRecord1.getUdpAddress().orElseThrow(),
+            mock(NodeSessionManager.class),
+            new LocalNodeRecordStore(
+                nodeRecord2, signer2, NodeRecordListener.NOOP, NewAddressHandler.NOOP),
+            signer2,
+            nodeBucketStorage2,
+            outgoingMessages2to1,
+            rnd,
+            requestExpirationScheduler);
+
+    Scheduler taskScheduler = Schedulers.createDefault().events();
+    Pipeline outgoingPipeline = new PipelineImpl().build();
+    WhoAreYouPacketHandler whoAreYouPacketHandlerNode1 =
+        new WhoAreYouPacketHandler(outgoingPipeline, taskScheduler);
+
+    // Step 1: Node1 sends ordinary packet n1.
+    nodeSessionAt1For2.sendOutgoingRandom(Bytes.random(128));
+    Bytes12 firstMessageNonce = nodeSessionAt1For2.getLastOutboundNonce().orElseThrow();
+    outgoing1Packets.clear();
+
+    // Step 2: Node2 issues WHOAREYOU c1 for n1.
+    Bytes16 firstIdNonce = Bytes16.random(rnd);
+    WhoAreYouPacket firstWhoAreYouPacket =
+        WhoAreYouPacket.create(
+            Header.createWhoAreYouHeader(firstMessageNonce, firstIdNonce, UInt64.ZERO));
+    nodeSessionAt2For1.sendOutgoingWhoAreYou(firstWhoAreYouPacket);
+
+    // Step 3: Node1 receives c1 and produces a handshake signed against it. Hold the handshake.
+    Envelope envelopeAt1From2 = new Envelope();
+    envelopeAt1From2.put(Field.PACKET_WHOAREYOU, firstWhoAreYouPacket);
+    envelopeAt1From2.put(Field.SESSION, nodeSessionAt1For2);
+    Request<Void> request =
+        new Request<>(
+            new CompletableFuture<>(),
+            id -> new FindNodeMessage(id, singletonList(1)),
+            new FindNodeResponseHandler(singletonList(1), ALLOW_ALL));
+    nodeSessionAt1For2.createNextRequest(request);
+
+    RawPacket firstWhoAreYouRawPacket = outgoing2Packets.poll(1, TimeUnit.SECONDS);
+    envelopeAt1From2.put(MASKING_IV, firstWhoAreYouRawPacket.getMaskingIV());
+    whoAreYouPacketHandlerNode1.handle(envelopeAt1From2);
+
+    RawPacket heldHandshakeRawPacket = outgoing1Packets.poll(1, TimeUnit.SECONDS);
+    assertNotNull(heldHandshakeRawPacket);
+
+    // Step 4: Before the handshake is delivered, Node1 sends a second ordinary packet n2, and
+    // Node2 issues a fresh WHOAREYOU c2 for it. With the fix, both c1 and c2 are tracked.
+    Bytes12 secondMessageNonce = Bytes12.wrap(Bytes.random(12));
+    Bytes16 secondIdNonce = Bytes16.random(rnd);
+    WhoAreYouPacket secondWhoAreYouPacket =
+        WhoAreYouPacket.create(
+            Header.createWhoAreYouHeader(secondMessageNonce, secondIdNonce, UInt64.ZERO));
+    nodeSessionAt2For1.sendOutgoingWhoAreYou(secondWhoAreYouPacket);
+    // Two challenges are now pending on the responder.
+    assertTrue(nodeSessionAt2For1.hasPendingWhoAreYouForNonce(firstMessageNonce));
+    assertTrue(nodeSessionAt2For1.hasPendingWhoAreYouForNonce(secondMessageNonce));
+
+    // Step 5: Deliver the held handshake (signed against c1) to Node2.
+    HandshakeMessagePacketHandler handshakeMessagePacketHandlerNode2 =
+        new HandshakeMessagePacketHandler(
+            outgoingPipeline,
+            taskScheduler,
+            NODE_RECORD_FACTORY_NO_VERIFICATION,
+            mock(NodeSessionManager.class),
+            ALLOW_ALL);
+    Envelope envelopeAt2From1 = new Envelope();
+    envelopeAt2From1.put(
+        PACKET_HANDSHAKE,
+        (HandshakeMessagePacket)
+            heldHandshakeRawPacket.demaskPacket(nodePair2.getNodeRecord().getNodeId()));
+    envelopeAt2From1.put(SESSION, nodeSessionAt2For1);
+    envelopeAt2From1.put(MASKING_IV, heldHandshakeRawPacket.getMaskingIV());
+    assertFalse(nodeSessionAt2For1.isAuthenticated());
+
+    handshakeMessagePacketHandlerNode2.handle(envelopeAt2From1);
+
+    // Step 6: Responder must accept the handshake and authenticate the session.
+    assertTrue(nodeSessionAt2For1.isAuthenticated());
+    assertNotNull(envelopeAt2From1.get(MESSAGE));
+    assertNull(envelopeAt2From1.get(BAD_PACKET));
+  }
+
   private OrdinaryMessagePacket createPingPacket(
       Bytes16 maskingIV, Bytes12 authTag, NodeSession session, Bytes requestId) {
 

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/UnauthorizedMessagePacketHandlerTest.java
@@ -31,29 +31,29 @@ class UnauthorizedMessagePacketHandlerTest {
   private final UnauthorizedMessagePacketHandler handler = new UnauthorizedMessagePacketHandler();
 
   @Test
-  void shouldResendExistingWhoAreYouWhenInWhoAreYouSentState() {
+  void shouldResendExistingWhoAreYouWhenNonceMatchesPending() {
     final NodeSession session = mock(NodeSession.class);
     when(session.getState()).thenReturn(SessionState.WHOAREYOU_SENT);
 
     final OrdinaryMessagePacket packet = createOrdinaryPacket();
     final Bytes12 nonce = packet.getHeader().getStaticHeader().getNonce();
-    when(session.getPendingWhoAreYouNonce()).thenReturn(Optional.of(nonce));
+    when(session.hasPendingWhoAreYouForNonce(nonce)).thenReturn(true);
 
     handler.handle(envelopeWith(session, packet));
 
-    verify(session).resendOutgoingWhoAreYou();
+    verify(session).resendOutgoingWhoAreYouFor(nonce);
     verify(session, never()).sendOutgoingWhoAreYou(any());
     verify(session, never()).setState(any());
   }
 
   @Test
-  void shouldNotChangeStateWhenResendingInWhoAreYouSentState() {
+  void shouldNotChangeStateWhenResendingForKnownNonce() {
     final NodeSession session = mock(NodeSession.class);
     when(session.getState()).thenReturn(SessionState.WHOAREYOU_SENT);
 
     final OrdinaryMessagePacket packet = createOrdinaryPacket();
     final Bytes12 nonce = packet.getHeader().getStaticHeader().getNonce();
-    when(session.getPendingWhoAreYouNonce()).thenReturn(Optional.of(nonce));
+    when(session.hasPendingWhoAreYouForNonce(nonce)).thenReturn(true);
 
     handler.handle(envelopeWith(session, packet));
 
@@ -61,22 +61,22 @@ class UnauthorizedMessagePacketHandlerTest {
   }
 
   @Test
-  void shouldSendNewWhoAreYouWhenInWhoAreYouSentStateButDifferentNonce() {
+  void shouldSendNewWhoAreYouWhenIncomingNonceIsUnknown() {
     final NodeSession session = mock(NodeSession.class);
     when(session.getState()).thenReturn(SessionState.WHOAREYOU_SENT);
     when(session.getNodeRecord()).thenReturn(Optional.empty());
-    // Pending WhoAreYou was for a different nonce
-    when(session.getPendingWhoAreYouNonce())
-        .thenReturn(Optional.of(Bytes12.wrap(Bytes.random(12))));
 
     final OrdinaryMessagePacket packet = createOrdinaryPacket();
+    final Bytes12 incomingNonce = packet.getHeader().getStaticHeader().getNonce();
+    // No pending WhoAreYou for this nonce — an earlier challenge was for a different nonce.
+    when(session.hasPendingWhoAreYouForNonce(incomingNonce)).thenReturn(false);
+
     handler.handle(envelopeWith(session, packet));
 
-    verify(session, never()).resendOutgoingWhoAreYou();
+    verify(session, never()).resendOutgoingWhoAreYouFor(any());
     final ArgumentCaptor<WhoAreYouPacket> captor = ArgumentCaptor.forClass(WhoAreYouPacket.class);
     verify(session).sendOutgoingWhoAreYou(captor.capture());
-    final Bytes12 expectedNonce = packet.getHeader().getStaticHeader().getNonce();
-    assertThat(captor.getValue().getHeader().getStaticHeader().getNonce()).isEqualTo(expectedNonce);
+    assertThat(captor.getValue().getHeader().getStaticHeader().getNonce()).isEqualTo(incomingNonce);
   }
 
   @Test
@@ -90,7 +90,7 @@ class UnauthorizedMessagePacketHandlerTest {
 
     final ArgumentCaptor<WhoAreYouPacket> captor = ArgumentCaptor.forClass(WhoAreYouPacket.class);
     verify(session).sendOutgoingWhoAreYou(captor.capture());
-    verify(session, never()).resendOutgoingWhoAreYou();
+    verify(session, never()).resendOutgoingWhoAreYouFor(any());
     verify(session).setState(SessionState.WHOAREYOU_SENT);
 
     // The WHOAREYOU nonce must echo the incoming packet's nonce so the initiator can
@@ -107,7 +107,7 @@ class UnauthorizedMessagePacketHandlerTest {
 
     handler.handle(envelope);
 
-    verify(session, never()).resendOutgoingWhoAreYou();
+    verify(session, never()).resendOutgoingWhoAreYouFor(any());
     verify(session, never()).sendOutgoingWhoAreYou(any());
   }
 

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
@@ -301,6 +301,30 @@ public class NodeSessionTest {
   }
 
   @Test
+  void pendingWhoAreYou_shouldEvictLeastRecentlyAccessedEntry() {
+    // Fill the cache to capacity.
+    final Bytes12[] nonces = new Bytes12[NodeSession.MAX_PENDING_WHOAREYOU];
+    for (int i = 0; i < nonces.length; i++) {
+      nonces[i] = Bytes12.wrap(Bytes.random(12));
+      session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonces[i]));
+    }
+
+    // Touch the eldest entry via a resend so it becomes most-recently-used.
+    session.resendOutgoingWhoAreYouFor(nonces[0]);
+
+    // Inserting one more must evict the now-eldest (nonces[1]), not nonces[0].
+    final Bytes12 newNonce = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(newNonce));
+
+    assertThat(session.hasPendingWhoAreYouForNonce(nonces[0])).isTrue();
+    assertThat(session.hasPendingWhoAreYouForNonce(nonces[1])).isFalse();
+    for (int i = 2; i < nonces.length; i++) {
+      assertThat(session.hasPendingWhoAreYouForNonce(nonces[i])).isTrue();
+    }
+    assertThat(session.hasPendingWhoAreYouForNonce(newNonce)).isTrue();
+  }
+
+  @Test
   void clearPendingWhoAreYouChallenges_shouldClearAllPending() {
     final Bytes12 nonce1 = Bytes12.wrap(Bytes.random(12));
     final Bytes12 nonce2 = Bytes12.wrap(Bytes.random(12));

--- a/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/schema/NodeSessionTest.java
@@ -198,14 +198,15 @@ public class NodeSessionTest {
   }
 
   @Test
-  void resendOutgoingWhoAreYou_shouldSendPacketWhenPendingPacketExists() {
-    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(Bytes12.wrap(Bytes.random(12))));
+  void resendOutgoingWhoAreYouFor_shouldSendPacketWhenPendingPacketExists() {
+    final Bytes12 nonce = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce));
 
     final ArgumentCaptor<NetworkParcelV5> firstCaptor =
         ArgumentCaptor.forClass(NetworkParcelV5.class);
     verify(outgoingPipeline).accept(firstCaptor.capture());
 
-    session.resendOutgoingWhoAreYou();
+    session.resendOutgoingWhoAreYouFor(nonce);
 
     final ArgumentCaptor<NetworkParcelV5> secondCaptor =
         ArgumentCaptor.forClass(NetworkParcelV5.class);
@@ -215,46 +216,126 @@ public class NodeSessionTest {
   }
 
   @Test
-  void resendOutgoingWhoAreYou_shouldDoNothingWhenNoPendingPacket() {
-    session.resendOutgoingWhoAreYou();
+  void resendOutgoingWhoAreYouFor_shouldDoNothingWhenNoPendingPacket() {
+    session.resendOutgoingWhoAreYouFor(Bytes12.wrap(Bytes.random(12)));
 
     verify(outgoingPipeline, never()).accept(any());
   }
 
   @Test
-  void resendOutgoingWhoAreYou_shouldDoNothingAfterHandshakeStateReset() {
+  void resendOutgoingWhoAreYouFor_shouldDoNothingForUnknownNonce() {
+    final Bytes12 storedNonce = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(storedNonce));
+    verify(outgoingPipeline, times(1)).accept(any());
+
+    session.resendOutgoingWhoAreYouFor(Bytes12.wrap(Bytes.random(12)));
+
+    verify(outgoingPipeline, times(1)).accept(any());
+  }
+
+  @Test
+  void resendOutgoingWhoAreYouFor_shouldDoNothingAfterHandshakeStateReset() {
     final Request<?> request = createRequestMock();
     final RequestInfo requestInfo = session.createNextRequest(request);
 
     final ArgumentCaptor<Runnable> timeoutHandlerCaptor = ArgumentCaptor.forClass(Runnable.class);
     verify(expirationScheduler).put(eq(requestInfo.getRequestId()), timeoutHandlerCaptor.capture());
 
-    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(Bytes12.wrap(Bytes.random(12))));
+    final Bytes12 nonce = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce));
     session.setState(SessionState.WHOAREYOU_SENT);
 
     // Simulate request timeout which resets the handshake state.
     timeoutHandlerCaptor.getValue().run();
     assertThat(session.getState()).isEqualTo(SessionState.INITIAL);
 
-    session.resendOutgoingWhoAreYou();
+    session.resendOutgoingWhoAreYouFor(nonce);
 
     // sendOutgoingWhoAreYou was called once above; resend should not add another send.
     verify(outgoingPipeline, times(1)).accept(any());
   }
 
   @Test
-  void resendOutgoingWhoAreYou_shouldPreserveOriginalNonce() {
+  void resendOutgoingWhoAreYouFor_shouldPreserveOriginalChallenge() {
     final Bytes12 originalNonce = Bytes12.wrap(Bytes.random(12));
-    final WhoAreYouPacket originalPacket = createWhoAreYouPacket(originalNonce);
-    session.sendOutgoingWhoAreYou(originalPacket);
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(originalNonce));
 
-    final Bytes challengeAfterSend = session.getWhoAreYouChallenge().orElseThrow();
+    final Bytes challengeAfterSend = singleChallenge();
 
-    session.resendOutgoingWhoAreYou();
+    session.resendOutgoingWhoAreYouFor(originalNonce);
 
     // Challenge must be unchanged after resend so a handshake signed against the original
     // challenge remains valid.
-    assertThat(session.getWhoAreYouChallenge()).contains(challengeAfterSend);
+    assertThat(singleChallenge()).isEqualTo(challengeAfterSend);
+  }
+
+  @Test
+  void sendOutgoingWhoAreYou_shouldStoreMultiplePendingChallengesWithoutOverwriting() {
+    final Bytes12 nonce1 = Bytes12.wrap(Bytes.random(12));
+    final Bytes12 nonce2 = Bytes12.wrap(Bytes.random(12));
+
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce1));
+    final Bytes challenge1 = singleChallenge();
+
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce2));
+
+    assertThat(session.hasPendingWhoAreYouForNonce(nonce1)).isTrue();
+    assertThat(session.hasPendingWhoAreYouForNonce(nonce2)).isTrue();
+    assertThat(session.getPendingWhoAreYouChallenges()).hasSize(2).contains(challenge1);
+  }
+
+  @Test
+  void pendingWhoAreYou_shouldBeBoundedAndEvictOldestEntry() {
+    final Bytes12[] nonces = new Bytes12[NodeSession.MAX_PENDING_WHOAREYOU + 1];
+    for (int i = 0; i < nonces.length; i++) {
+      nonces[i] = Bytes12.wrap(Bytes.random(12));
+      session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonces[i]));
+    }
+
+    // The oldest entry must have been evicted to keep the map bounded.
+    assertThat(session.hasPendingWhoAreYouForNonce(nonces[0])).isFalse();
+    for (int i = 1; i < nonces.length; i++) {
+      assertThat(session.hasPendingWhoAreYouForNonce(nonces[i])).isTrue();
+    }
+    assertThat(session.getPendingWhoAreYouChallenges()).hasSize(NodeSession.MAX_PENDING_WHOAREYOU);
+  }
+
+  @Test
+  void clearPendingWhoAreYouChallenges_shouldClearAllPending() {
+    final Bytes12 nonce1 = Bytes12.wrap(Bytes.random(12));
+    final Bytes12 nonce2 = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce1));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce2));
+    assertThat(session.getPendingWhoAreYouChallenges()).hasSize(2);
+
+    session.clearPendingWhoAreYouChallenges();
+
+    assertThat(session.getPendingWhoAreYouChallenges()).isEmpty();
+    assertThat(session.hasPendingWhoAreYouForNonce(nonce1)).isFalse();
+    assertThat(session.hasPendingWhoAreYouForNonce(nonce2)).isFalse();
+  }
+
+  @Test
+  void resetHandshakeState_shouldClearAllPendingChallenges() {
+    final Request<?> request = createRequestMock();
+    final RequestInfo requestInfo = session.createNextRequest(request);
+    final ArgumentCaptor<Runnable> timeoutHandlerCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(expirationScheduler).put(eq(requestInfo.getRequestId()), timeoutHandlerCaptor.capture());
+
+    final Bytes12 nonce1 = Bytes12.wrap(Bytes.random(12));
+    final Bytes12 nonce2 = Bytes12.wrap(Bytes.random(12));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce1));
+    session.sendOutgoingWhoAreYou(createWhoAreYouPacket(nonce2));
+    session.setState(SessionState.WHOAREYOU_SENT);
+
+    timeoutHandlerCaptor.getValue().run();
+
+    assertThat(session.getState()).isEqualTo(SessionState.INITIAL);
+    assertThat(session.getPendingWhoAreYouChallenges()).isEmpty();
+  }
+
+  private Bytes singleChallenge() {
+    return session.getPendingWhoAreYouChallenges().iterator().next();
   }
 
   private static WhoAreYouPacket createWhoAreYouPacket(final Bytes12 nonce) {


### PR DESCRIPTION
## PR Description

A WHOAREYOU issued for a new ordinary packet nonce used to overwrite any prior pending challenge on the same session. When the initiator's handshake — signed against the earlier challenge — finally arrived, `HandshakeMessagePacketHandler` validated it against the replacement and dropped the session.

`NodeSession` now keeps a bounded (LRU, max 5) set of pending WHOAREYOU challenges keyed by the ordinary packet nonce that caused each one. `HandshakeMessagePacketHandler` iterates the pending challenges and accepts the one whose ID signature verifies, then clears the set. The set is also cleared on `resetHandshakeState()`.

Behavior summary:
- Same ordinary nonce seen again → resend the existing WHOAREYOU for that nonce (unchanged from #219).
- Different ordinary nonce while waiting for a handshake → queue a new WHOAREYOU without invalidating earlier pending challenges.
- Handshake arrives → match against any unexpired pending challenge.
- Successful authentication or handshake-state reset → clear pending challenges.
- LRU bound keeps the cache memory-safe under load.

### Tests
- Regression test `HandshakeHandlersTest.responderAcceptsHandshakeForEarlierPendingWhoAreYou` reproduces the interleaving in the issue: `n1 → c1`, handshake-for-c1 held, `n2 → c2`, then handshake-for-c1 delivered — responder must authenticate.
- New `NodeSessionTest` cases covering multi-challenge storage, LRU eviction, `clearPendingWhoAreYouChallenges`, and `resetHandshakeState` clearing.
- Updated `UnauthorizedMessagePacketHandlerTest` for the new `hasPendingWhoAreYouForNonce` / `resendOutgoingWhoAreYouFor(nonce)` API.

## Fixed Issue(s)
fixes #228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes discv5 handshake state tracking and signature validation across multiple pending WHOAREYOU challenges, which can affect session authentication behavior under packet reordering/retransmission. Logic is bounded and covered by new regression/unit tests, but it touches core handshake flow.
> 
> **Overview**
> Fixes a handshake edge case where issuing a new `WHOAREYOU` would overwrite the prior pending challenge, causing delayed handshakes to fail authentication.
> 
> `NodeSession` now retains a bounded (LRU, max `5`) map of pending `WHOAREYOU` challenges keyed by ordinary packet nonce, adds nonce-specific resend APIs, and clears all pending challenges on successful authentication or handshake-state reset.
> 
> `HandshakeMessagePacketHandler` now tries *all* pending challenges to find one whose ID signature verifies before deriving session keys, and `UnauthorizedMessagePacketHandler` resends the existing challenge only when the incoming nonce matches a queued one; tests were updated and expanded with a regression for the interleaving scenario plus LRU/clearing coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1f75f6455facd61e5a9300e7bf7608b042d253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->