### PR TITLE
test: fix flake in shouldRecoverAfterErrorWhileDecodingInboundMessage

### DIFF
--- a/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/integration/DiscoveryIntegrationTest.java
@@ -378,6 +378,17 @@ public class DiscoveryIntegrationTest {
             bootnode.getLocalNodeRecord());
     final DiscoverySystem otherClient = createDiscoveryClient(client.getLocalNodeRecord());
 
+    // Warm-up: ensure the otherClient<->client session is fully authenticated BEFORE we
+    // enable the error injection. Without this, otherClient's startup auto-ping to its
+    // bootnode (client) races with throwError.set(true) below; if otherClient's
+    // HandshakeMessagePacket happens to land on client during the error window, the buggy
+    // factory throws StackOverflowError while decoding otherClient's ENR, client drops the
+    // session, and recovery becomes unreliable.
+    final CompletableFuture<Void> warmupPing = otherClient.ping(client.getLocalNodeRecord());
+    waitFor(warmupPing, 60);
+    assertTrue(warmupPing.isDone());
+    assertFalse(warmupPing.isCompletedExceptionally());
+
     final CompletableFuture<Void> pingResult = client.ping(bootnode.getLocalNodeRecord());
     waitFor(pingResult, 60);
     assertTrue(pingResult.isDone());


### PR DESCRIPTION
## PR Description

`DiscoveryIntegrationTest.shouldRecoverAfterErrorWhileDecodingInboundMessage` flakes intermittently in CI with `java.util.concurrent.TimeoutException at DiscoveryIntegrationTest.java:397`. Reproduced locally as **15 failures across 50 in-process iterations (30% flake rate)**.

### Root cause — race in the test setup, not a production bug

1. The test creates `otherClient` with `client.getLocalNodeRecord()` as its bootnode. `DiscoverySystem.start()` initiates an auto-ping to each bootnode, so `otherClient` asynchronously begins handshaking with `client` (PING → WHOAREYOU → HandshakeMessagePacket).
2. The test then enables error injection via `buggyNodeRecordFactory.throwError.set(true)` before either `client`'s own setup-ping or the explicit `findNodes` call.
3. If `otherClient`'s HandshakeMessagePacket happens to be processed by `client` *during* the error window, the buggy factory throws `StackOverflowError` while decoding `otherClient`'s ENR. Client's `HandshakeMessagePacketHandler` catches `Throwable`, calls `markHandshakeAsFailed` → `nodeSessionManager.dropSession`, leaving `client` without a session for `otherClient`.
4. After the error window ends, recovery via the explicit `otherClient.ping(client)` is intermittently unreliable for reasons orthogonal to what this test is intended to verify.

### Why this is not another #205

This is **not** a re-attempt of #205 (which the team did not actually roll back: revert PR #217 was closed without merging, and #218 added the `AbstractSkippingEnvelopeHandler` complement). Both protective layers — `PipelineImpl` handler wrap, `MessagePacketHandler` Throwable catch, `HandshakeMessagePacketHandler` Throwable catch — are still on `master`.

**No production code is changed.** The fix is to explicitly complete the `otherClient`↔`client` handshake before enabling error injection, isolating the test to the path it claims to exercise (decode failures on the `client`↔`bootnode` findNodes flow).

### Diagnostic evidence

Captured with temporary `LOG.info` traces in `MessagePacketHandler`, `IncomingMessageSink`, `HandshakeMessagePacketHandler`, `PipelineImpl`, and `NodeSession` (since reverted). In a failing iteration:

```
13:55:44.704 MessagePacketHandler StackOverflowError caught session=... state=AUTHENTICATED peer=9011 (bootnode)
13:55:44.705 HandshakeMessagePacketHandler markHandshakeAsFailed session=869452968 state=WHOAREYOU_SENT nodeRec=Optional.empty
13:55:45.728 HandshakeMessagePacketHandler markHandshakeAsFailed session=685162660 state=WHOAREYOU_SENT nodeRec=Optional.empty
```

The two `markHandshakeAsFailed` calls (different session ids, both `nodeRec=Optional.empty`) are otherClient's auto-ping handshake retries being broken by the buggy factory. The 60s `waitFor` then times out because the recovery exchange after the error window doesn't complete in time.

### Test plan

- [x] `./gradlew test --tests "...stressRecoverAfterErrorWhileDecodingInboundMessage" --rerun-tasks` with a temporary `@RepeatedTest(50)` wrapper on the test method:
  - **Before fix**: 15 failures / 50 iterations (30% flake)
  - **After fix**: 0 failures / 50 iterations
- [x] `./gradlew build` clean
- [x] Diff is one file, +11 lines, comment included

## Fixed Issue(s)

Tracked separately (see internal flaky-test note).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a deterministic pre-handshake to remove a race around injected decode failures.
> 
> **Overview**
> Fixes a CI flake in `DiscoveryIntegrationTest.shouldRecoverAfterErrorWhileDecodingInboundMessage` by adding an explicit warm-up `ping` from `otherClient` to `client` before toggling `buggyNodeRecordFactory.throwError`.
> 
> This prevents `otherClient`'s startup auto-ping/handshake from racing with the injected `StackOverflowError`, making the subsequent recovery assertions reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2312b3a434fbbaa98180f5564607dfca7ec8a4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->