### PR TITLE
Update Netty 4.1→4.2 and companion dependency upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'io.projectreactor:reactor-core'
   implementation 'io.netty:netty-all'
+  compileOnly 'org.jspecify:jspecify'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.logging.log4j:log4j-core'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,24 +9,25 @@ dependencyManagement {
 
     dependency 'io.consensys.protocols:errorprone-checks:1.1.2'
 
-    dependency 'com.google.guava:guava:33.2.1-jre'
+    dependency 'com.google.guava:guava:33.6.0-jre'
 
-    dependency "io.netty:netty-all:4.1.115.Final"
+    dependency "io.netty:netty-all:4.2.15.Final"
+    dependency 'org.jspecify:jspecify:1.0.0'
     dependency 'io.projectreactor:reactor-core:3.6.7'
 
-    dependencySet(group: 'org.apache.logging.log4j', version: '2.23.1') {
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.26.0') {
       entry 'log4j-api'
       entry 'log4j-core'
       entry 'log4j-slf4j-impl'
     }
 
-    dependency 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    dependency 'org.bouncycastle:bcprov-jdk18on:1.84'
 
     dependency 'org.assertj:assertj-core:3.26.0'
     dependency 'org.mockito:mockito-core:5.12.0'
 
-    dependency 'io.vertx:vertx-core:4.5.9'
-    dependencySet(group: 'io.consensys.tuweni', version: '2.7.0') {
+    dependency 'io.vertx:vertx-core:4.5.28'
+    dependencySet(group: 'io.consensys.tuweni', version: '2.7.2') {
       entry 'tuweni-bytes'
       entry 'tuweni-crypto'
       entry 'tuweni-rlp'

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoveryManagerImpl.java
@@ -7,10 +7,11 @@ package org.ethereum.beacon.discovery;
 import static org.ethereum.beacon.discovery.util.Utils.RECOVERABLE_ERRORS_PREDICATE;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -62,13 +63,12 @@ import org.ethereum.beacon.discovery.storage.KBuckets;
 import org.ethereum.beacon.discovery.storage.LocalNodeRecordStore;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Sinks;
 
 public class DiscoveryManagerImpl implements DiscoveryManager {
   private static final Logger LOG = LogManager.getLogger();
 
-  private final ReplayProcessor<NetworkParcel> outgoingMessages = ReplayProcessor.cacheLast();
+  private final Sinks.Many<NetworkParcel> outgoingMessages = Sinks.many().replay().latest();
   private final List<NettyDiscoveryServer> discoveryServers;
   private final Pipeline incomingPipeline = new PipelineImpl();
   private final Pipeline outgoingPipeline = new PipelineImpl();
@@ -133,9 +133,8 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
                 this::requestUpdatedEnr,
                 externalAddressSelector))
         .addHandler(new BadPacketHandler());
-    final FluxSink<NetworkParcel> outgoingSink = outgoingMessages.sink();
     outgoingPipeline
-        .addHandler(new OutgoingParcelHandler(outgoingSink, addressAccessPolicy))
+        .addHandler(new OutgoingParcelHandler(outgoingMessages, addressAccessPolicy))
         .addHandler(new NodeSessionRequestHandler())
         .addHandler(nodeSessionManager)
         .addHandler(new NewTaskHandler())
@@ -163,7 +162,7 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
                     RECOVERABLE_ERRORS_PREDICATE,
                     (err, msg) -> LOG.debug("Error while processing message", err))
                 .subscribe());
-    final Map<InternetProtocolFamily, NioDatagramChannel> channels = new ConcurrentHashMap<>();
+    final Map<StandardProtocolFamily, NioDatagramChannel> channels = new ConcurrentHashMap<>();
     return CompletableFuture.allOf(
             discoveryServers.stream()
                 .map(
@@ -183,11 +182,13 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
                                   // of how the caller configured external address changes.
                                   localNodeRecordStore.onBoundPortResolved(boundAddress);
                                   channels.put(
-                                      InternetProtocolFamily.of(boundAddress.getAddress()),
-                                      channel);
+                                      protocolFamilyOf(boundAddress.getAddress()), channel);
                                 }))
                 .toArray(CompletableFuture<?>[]::new))
-        .thenRun(() -> discoveryClient = new NettyDiscoveryClientImpl(outgoingMessages, channels));
+        .thenRun(
+            () ->
+                discoveryClient =
+                    new NettyDiscoveryClientImpl(outgoingMessages.asFlux(), channels));
   }
 
   @Override
@@ -252,7 +253,7 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
 
   @VisibleForTesting
   public Publisher<NetworkParcel> getOutgoingMessages() {
-    return outgoingMessages;
+    return outgoingMessages.asFlux();
   }
 
   @VisibleForTesting
@@ -273,5 +274,11 @@ public class DiscoveryManagerImpl implements DiscoveryManager {
   @Override
   public Stream<NodeRecord> streamActiveSessions() {
     return nodeSessionManager.streamActiveSessions();
+  }
+
+  private static StandardProtocolFamily protocolFamilyOf(final InetAddress address) {
+    return address instanceof Inet6Address
+        ? StandardProtocolFamily.INET6
+        : StandardProtocolFamily.INET;
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
+++ b/src/main/java/org/ethereum/beacon/discovery/DiscoverySystemBuilder.java
@@ -13,9 +13,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.netty.channel.socket.InternetProtocolFamily;
 import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -185,16 +186,22 @@ public class DiscoverySystemBuilder {
         listenAddresses.size() == 1 || listenAddresses.size() == 2,
         "Can define only 1 or 2 listen addresses - IPv4/IPv6 or IPv4 and IPv6");
     if (listenAddresses.size() == 2) {
-      final Set<InternetProtocolFamily> ipFamilies =
+      final Set<StandardProtocolFamily> ipFamilies =
           listenAddresses.stream()
               .map(InetSocketAddress::getAddress)
-              .map(InternetProtocolFamily::of)
+              .map(DiscoverySystemBuilder::protocolFamilyOf)
               .collect(Collectors.toSet());
       if (ipFamilies.size() != 2) {
         throw new IllegalArgumentException(
             String.format("Expected an IPv4 and an IPv6 address but only %s was set", ipFamilies));
       }
     }
+  }
+
+  private static StandardProtocolFamily protocolFamilyOf(final InetAddress address) {
+    return address instanceof Inet6Address
+        ? StandardProtocolFamily.INET6
+        : StandardProtocolFamily.INET;
   }
 
   private void createDefaults() {

--- a/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
+++ b/src/main/java/org/ethereum/beacon/discovery/database/ExpirationSet.java
@@ -37,7 +37,7 @@ public class ExpirationSet<V extends Comparable<V>> {
         Collections.newSetFromMap(
             CacheBuilder.newBuilder()
                 .maximumSize(maxSize)
-                .expireAfterWrite(expirationDelayMillis, TimeUnit.MILLISECONDS)
+                .expireAfterWrite(Duration.ofMillis(expirationDelayMillis))
                 .ticker(
                     new Ticker() {
                       @Override

--- a/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
@@ -28,7 +28,10 @@ public class IncomingMessageSink extends SimpleChannelInboundHandler<Envelope> {
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, Envelope msg) {
     LOG.trace(() -> String.format("Incoming packet %s in session %s", msg, ctx));
-    messageSink.tryEmitNext(msg);
+    final Sinks.EmitResult result = messageSink.tryEmitNext(msg);
+    if (result.isFailure()) {
+      LOG.warn("Failed to emit incoming packet {} in session {}: {}", msg, ctx, result);
+    }
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/IncomingMessageSink.java
@@ -10,25 +10,25 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
-import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Sinks;
 
 /**
  * Netty interface handler for incoming packets in form of raw bytes data wrapped as {@link Bytes}
- * Implementation forwards all incoming packets in {@link FluxSink} provided via constructor, so it
- * could be later linked to processor to form incoming messages stream
+ * Implementation forwards all incoming packets in {@link Sinks.Many} provided via constructor, so
+ * it could be later linked to processor to form incoming messages stream
  */
 public class IncomingMessageSink extends SimpleChannelInboundHandler<Envelope> {
   private static final Logger LOG = LogManager.getLogger(IncomingMessageSink.class);
-  private final FluxSink<Envelope> messageSink;
+  private final Sinks.Many<Envelope> messageSink;
 
-  public IncomingMessageSink(FluxSink<Envelope> messageSink) {
+  public IncomingMessageSink(Sinks.Many<Envelope> messageSink) {
     this.messageSink = messageSink;
   }
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, Envelope msg) {
     LOG.trace(() -> String.format("Incoming packet %s in session %s", msg, ctx));
-    messageSink.next(msg);
+    messageSink.tryEmitNext(msg);
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryClientImpl.java
@@ -6,9 +6,11 @@ package org.ethereum.beacon.discovery.network;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.socket.DatagramPacket;
-import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,7 +22,7 @@ import reactor.core.publisher.Flux;
 public class NettyDiscoveryClientImpl implements DiscoveryClient {
   private static final Logger LOG = LogManager.getLogger(NettyDiscoveryClientImpl.class);
 
-  private final Map<InternetProtocolFamily, NioDatagramChannel> channels;
+  private final Map<StandardProtocolFamily, NioDatagramChannel> channels;
 
   /**
    * Constructs UDP client using
@@ -30,7 +32,7 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
    */
   public NettyDiscoveryClientImpl(
       final Publisher<NetworkParcel> outgoingStream,
-      final Map<InternetProtocolFamily, NioDatagramChannel> channels) {
+      final Map<StandardProtocolFamily, NioDatagramChannel> channels) {
     this.channels = channels;
     Flux.from(outgoingStream)
         .subscribe(
@@ -46,8 +48,7 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
   public void send(final Bytes data, final InetSocketAddress destination) {
     final DatagramPacket packet =
         new DatagramPacket(Unpooled.copiedBuffer(data.toArray()), destination);
-    final NioDatagramChannel channel =
-        channels.get(InternetProtocolFamily.of(destination.getAddress()));
+    final NioDatagramChannel channel = channels.get(protocolFamilyOf(destination.getAddress()));
     if (channel == null) {
       LOG.trace(
           () -> String.format("Dropping packet %s because of IP version incompatibility", packet));
@@ -56,5 +57,11 @@ public class NettyDiscoveryClientImpl implements DiscoveryClient {
     LOG.trace(() -> String.format("Sending packet %s", packet));
     channel.write(packet);
     channel.flush();
+  }
+
+  private static StandardProtocolFamily protocolFamilyOf(final InetAddress address) {
+    return address instanceof Inet6Address
+        ? StandardProtocolFamily.INET6
+        : StandardProtocolFamily.INET;
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/network/NettyDiscoveryServerImpl.java
@@ -9,7 +9,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -21,21 +23,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Sinks;
 
 public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
 
   private static final Logger LOG = LogManager.getLogger(NettyDiscoveryServerImpl.class);
   private static final int RECREATION_TIMEOUT = 5000;
 
-  private final ReplayProcessor<Envelope> incomingPackets = ReplayProcessor.cacheLast();
-  private final FluxSink<Envelope> incomingSink = incomingPackets.sink();
+  private final Sinks.Many<Envelope> incomingPackets = Sinks.many().replay().latest();
   private final InetSocketAddress listenAddress;
   private final int trafficReadLimit; // bytes per sec
   private AtomicBoolean listen = new AtomicBoolean(false);
   private Channel channel;
-  private NioEventLoopGroup nioGroup;
+  private EventLoopGroup nioGroup;
 
   public NettyDiscoveryServerImpl(
       final InetSocketAddress listenAddress, final int trafficReadLimit) {
@@ -51,11 +51,11 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
           new IllegalStateException(
               "Attempted to start an already started server listening on " + listenAddress));
     }
-    nioGroup = new NioEventLoopGroup(1);
+    nioGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
     return startServer(nioGroup);
   }
 
-  private CompletableFuture<NioDatagramChannel> startServer(final NioEventLoopGroup group) {
+  private CompletableFuture<NioDatagramChannel> startServer(final EventLoopGroup group) {
     final CompletableFuture<NioDatagramChannel> future = new CompletableFuture<>();
     final Bootstrap b = new Bootstrap();
     b.group(group)
@@ -68,7 +68,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
                 pipeline
                     .addFirst(new LoggingHandler(LogLevel.TRACE))
                     .addLast(new DatagramToEnvelope())
-                    .addLast(new IncomingMessageSink(incomingSink));
+                    .addLast(new IncomingMessageSink(incomingPackets));
 
                 if (trafficReadLimit != 0) {
                   pipeline.addFirst(new ChannelTrafficShapingHandler(0, trafficReadLimit));
@@ -119,7 +119,7 @@ public class NettyDiscoveryServerImpl implements NettyDiscoveryServer {
 
   @Override
   public Publisher<Envelope> getIncomingPackets() {
-    return incomingPackets;
+    return incomingPackets.asFlux();
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
@@ -14,16 +14,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Sinks;
 
 public class PipelineImpl implements Pipeline {
   private static final Logger LOG = LogManager.getLogger();
 
   private final List<EnvelopeHandler> envelopeHandlers = new ArrayList<>();
   private final AtomicBoolean started = new AtomicBoolean(false);
-  private Flux<Envelope> pipeline = ReplayProcessor.cacheLast();
-  private final FluxSink<Envelope> pipelineSink = ((ReplayProcessor<Envelope>) pipeline).sink();
+  private final Sinks.Many<Envelope> pipelineSinks = Sinks.many().replay().latest();
+  private Flux<Envelope> pipeline = pipelineSinks.asFlux();
 
   @Override
   public synchronized Pipeline build() {
@@ -55,13 +54,16 @@ public class PipelineImpl implements Pipeline {
     if (!started.get()) {
       throw new RuntimeException("You should build pipeline first");
     }
+    final Envelope envelope;
     if (!(object instanceof Envelope)) {
-      Envelope envelope = new Envelope();
+      envelope = new Envelope();
       envelope.put(INCOMING, object);
-      pipelineSink.next(envelope);
     } else {
-      pipelineSink.next((Envelope) object);
+      envelope = (Envelope) object;
     }
+    // retry on FAIL_NON_SERIALIZED to handle concurrent push from multiple event-loop threads
+    pipelineSinks.emitNext(
+        envelope, (signalType, emitResult) -> emitResult == Sinks.EmitResult.FAIL_NON_SERIALIZED);
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/PipelineImpl.java
@@ -7,11 +7,13 @@ package org.ethereum.beacon.discovery.pipeline;
 import static org.ethereum.beacon.discovery.pipeline.Field.INCOMING;
 import static org.ethereum.beacon.discovery.util.Utils.RECOVERABLE_ERRORS_PREDICATE;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ethereum.beacon.discovery.util.Utils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
@@ -61,9 +63,13 @@ public class PipelineImpl implements Pipeline {
     } else {
       envelope = (Envelope) object;
     }
-    // retry on FAIL_NON_SERIALIZED to handle concurrent push from multiple event-loop threads
-    pipelineSinks.emitNext(
-        envelope, (signalType, emitResult) -> emitResult == Sinks.EmitResult.FAIL_NON_SERIALIZED);
+    // retry (bounded) on FAIL_NON_SERIALIZED to handle concurrent push from multiple
+    // event-loop threads
+    final Sinks.EmitResult result =
+        Utils.emitNextWithRetry(pipelineSinks, envelope, Duration.ofSeconds(1));
+    if (result.isFailure()) {
+      LOG.error("Failed to push envelope {} into pipeline: {}", envelope.getIdString(), result);
+    }
   }
 
   @Override

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
@@ -12,7 +12,7 @@ import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
-import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Sinks;
 
 /**
  * Looks up for {@link NetworkParcel} in {@link Field#INCOMING} field. If it's found, it shows that
@@ -22,11 +22,11 @@ import reactor.core.publisher.FluxSink;
 public class OutgoingParcelHandler extends AbstractSkippingEnvelopeHandler {
   private static final Logger LOG = LogManager.getLogger(OutgoingParcelHandler.class);
 
-  private final FluxSink<NetworkParcel> outgoingSink;
+  private final Sinks.Many<NetworkParcel> outgoingSink;
   private final AddressAccessPolicy addressAccessPolicy;
 
   public OutgoingParcelHandler(
-      FluxSink<NetworkParcel> outgoingSink, final AddressAccessPolicy addressAccessPolicy) {
+      Sinks.Many<NetworkParcel> outgoingSink, final AddressAccessPolicy addressAccessPolicy) {
     this.outgoingSink = outgoingSink;
     this.addressAccessPolicy = addressAccessPolicy;
   }
@@ -50,7 +50,7 @@ public class OutgoingParcelHandler extends AbstractSkippingEnvelopeHandler {
         LOG.trace(
             "Dropping outgoing packet to disallowed destination: {}", parcel.getDestination());
       } else {
-        outgoingSink.next(parcel);
+        outgoingSink.tryEmitNext(parcel);
         envelope.remove(Field.INCOMING);
       }
     }

--- a/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandler.java
@@ -4,6 +4,7 @@
 
 package org.ethereum.beacon.discovery.pipeline.handler;
 
+import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethereum.beacon.discovery.AddressAccessPolicy;
@@ -12,6 +13,7 @@ import org.ethereum.beacon.discovery.pipeline.AbstractSkippingEnvelopeHandler;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.ethereum.beacon.discovery.pipeline.HandlerUtil;
+import org.ethereum.beacon.discovery.util.Utils;
 import reactor.core.publisher.Sinks;
 
 /**
@@ -50,8 +52,13 @@ public class OutgoingParcelHandler extends AbstractSkippingEnvelopeHandler {
         LOG.trace(
             "Dropping outgoing packet to disallowed destination: {}", parcel.getDestination());
       } else {
-        outgoingSink.tryEmitNext(parcel);
-        envelope.remove(Field.INCOMING);
+        final Sinks.EmitResult result =
+            Utils.emitNextWithRetry(outgoingSink, parcel, Duration.ofSeconds(1));
+        if (result.isSuccess()) {
+          envelope.remove(Field.INCOMING);
+        } else {
+          LOG.error("Failed to emit outgoing packet to {}: {}", parcel.getDestination(), result);
+        }
       }
     }
   }

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/DelegatingReactorScheduler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/DelegatingReactorScheduler.java
@@ -6,7 +6,7 @@ package org.ethereum.beacon.discovery.scheduler;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler;
 
@@ -20,19 +20,19 @@ public class DelegatingReactorScheduler implements Scheduler {
     this.timeSupplier = timeSupplier;
   }
 
-  @Nonnull
+  @NonNull
   @Override
-  public Disposable schedule(@Nonnull Runnable task) {
+  public Disposable schedule(@NonNull Runnable task) {
     return delegate.schedule(task);
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
     return delegate.schedule(task, delay, unit);
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public Disposable schedulePeriodically(
       Runnable task, long initialDelay, long period, TimeUnit unit) {
@@ -44,7 +44,7 @@ public class DelegatingReactorScheduler implements Scheduler {
     return unit.convert(timeSupplier.get(), TimeUnit.MILLISECONDS);
   }
 
-  @Nonnull
+  @NonNull
   @Override
   public Worker createWorker() {
     return delegate.createWorker();
@@ -55,6 +55,7 @@ public class DelegatingReactorScheduler implements Scheduler {
     delegate.dispose();
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void start() {
     delegate.start();
@@ -72,19 +73,19 @@ public class DelegatingReactorScheduler implements Scheduler {
       this.delegate = delegate;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public Disposable schedule(@Nonnull Runnable task) {
+    public Disposable schedule(@NonNull Runnable task) {
       return delegate.schedule(task);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
       return delegate.schedule(task, delay, unit);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Disposable schedulePeriodically(
         Runnable task, long initialDelay, long period, TimeUnit unit) {

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/ErrorHandlingScheduler.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/ErrorHandlingScheduler.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import reactor.core.Disposable;
 
 public class ErrorHandlingScheduler implements Scheduler {
@@ -84,42 +84,42 @@ public class ErrorHandlingScheduler implements Scheduler {
       super(delegate, timeSupplier);
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public Disposable schedule(@Nonnull Runnable task) {
+    public Disposable schedule(@NonNull Runnable task) {
       return super.schedule(() -> runAndHandleError(task));
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
       return super.schedule(() -> runAndHandleError(task), delay, unit);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Disposable schedulePeriodically(
         Runnable task, long initialDelay, long period, TimeUnit unit) {
       return super.schedulePeriodically(() -> runAndHandleError(task), initialDelay, period, unit);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Worker createWorker() {
       return new DelegateWorker(super.createWorker()) {
-        @Nonnull
+        @NonNull
         @Override
-        public Disposable schedule(@Nonnull Runnable task) {
+        public Disposable schedule(@NonNull Runnable task) {
           return super.schedule(() -> runAndHandleError(task));
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
           return super.schedule(() -> runAndHandleError(task), delay, unit);
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public Disposable schedulePeriodically(
             Runnable task, long initialDelay, long period, TimeUnit unit) {

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/SimpleProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/SimpleProcessor.java
@@ -9,13 +9,10 @@ import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxProcessor;
-import reactor.core.publisher.FluxSink;
-import reactor.core.publisher.ReplayProcessor;
+import reactor.core.publisher.Sinks;
 
 public class SimpleProcessor<T> implements Processor<T, T> {
-  FluxProcessor<T, T> subscriber;
-  FluxSink<T> sink;
+  Sinks.Many<T> sinks;
   Flux<T> publisher;
   boolean subscribed;
 
@@ -29,10 +26,8 @@ public class SimpleProcessor<T> implements Processor<T, T> {
   }
 
   public SimpleProcessor(reactor.core.scheduler.Scheduler scheduler, String name) {
-    ReplayProcessor<T> processor = ReplayProcessor.cacheLast();
-    subscriber = processor;
-    sink = subscriber.sink();
-    publisher = Flux.from(processor).publishOn(scheduler).onBackpressureError().name(name);
+    sinks = Sinks.many().replay().latest();
+    publisher = sinks.asFlux().publishOn(scheduler).onBackpressureError().name(name);
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -53,7 +48,7 @@ public class SimpleProcessor<T> implements Processor<T, T> {
     publisher =
         publisher.doOnCancel(
             () -> {
-              if (subscribed && !subscriber.hasDownstreams()) {
+              if (subscribed && sinks.currentSubscriberCount() == 0) {
                 subscribed = false;
                 handler.run();
               }
@@ -68,21 +63,21 @@ public class SimpleProcessor<T> implements Processor<T, T> {
 
   @Override
   public void onSubscribe(Subscription subscription) {
-    subscriber.onSubscribe(subscription);
+    subscription.request(Long.MAX_VALUE);
   }
 
   @Override
   public void onNext(T t) {
-    sink.next(t);
+    sinks.tryEmitNext(t);
   }
 
   @Override
   public void onError(Throwable throwable) {
-    sink.error(throwable);
+    sinks.tryEmitError(throwable);
   }
 
   @Override
   public void onComplete() {
-    sink.complete();
+    sinks.tryEmitComplete();
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/scheduler/SimpleProcessor.java
+++ b/src/main/java/org/ethereum/beacon/discovery/scheduler/SimpleProcessor.java
@@ -5,6 +5,8 @@
 package org.ethereum.beacon.discovery.scheduler;
 
 // import org.ethereum.beacon.schedulers.Scheduler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -12,6 +14,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
 public class SimpleProcessor<T> implements Processor<T, T> {
+  private static final Logger LOG = LogManager.getLogger(SimpleProcessor.class);
   Sinks.Many<T> sinks;
   Flux<T> publisher;
   boolean subscribed;
@@ -68,16 +71,25 @@ public class SimpleProcessor<T> implements Processor<T, T> {
 
   @Override
   public void onNext(T t) {
-    sinks.tryEmitNext(t);
+    final Sinks.EmitResult result = sinks.tryEmitNext(t);
+    if (result.isFailure()) {
+      LOG.warn("Failed to emit next value {}: {}", t, result);
+    }
   }
 
   @Override
   public void onError(Throwable throwable) {
-    sinks.tryEmitError(throwable);
+    final Sinks.EmitResult result = sinks.tryEmitError(throwable);
+    if (result.isFailure()) {
+      LOG.warn("Failed to emit error {}: {}", throwable, result);
+    }
   }
 
   @Override
   public void onComplete() {
-    sinks.tryEmitComplete();
+    final Sinks.EmitResult result = sinks.tryEmitComplete();
+    if (result.isFailure()) {
+      LOG.warn("Failed to emit completion signal: {}", result);
+    }
   }
 }

--- a/src/main/java/org/ethereum/beacon/discovery/util/Utils.java
+++ b/src/main/java/org/ethereum/beacon/discovery/util/Utils.java
@@ -8,6 +8,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -18,6 +19,8 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import reactor.core.Exceptions;
+import reactor.core.publisher.SignalType;
+import reactor.core.publisher.Sinks;
 
 public class Utils {
 
@@ -120,5 +123,22 @@ public class Utils {
 
   public static boolean isPortValid(final int port) {
     return (port >= 0 && port <= 65535);
+  }
+
+  /**
+   * Emits {@code value} into {@code sink}, retrying on {@link Sinks.EmitResult#FAIL_NON_SERIALIZED}
+   * (raised when multiple threads push into the sink concurrently) for up to {@code retryTimeout}
+   * before giving up. Unlike {@link Sinks.Many#emitNext}, this never throws; the final {@link
+   * Sinks.EmitResult} is always returned so the caller can decide how to handle a failure.
+   */
+  public static <T> Sinks.EmitResult emitNextWithRetry(
+      Sinks.Many<T> sink, T value, Duration retryTimeout) {
+    final Sinks.EmitFailureHandler retryHandler =
+        Sinks.EmitFailureHandler.busyLooping(retryTimeout);
+    Sinks.EmitResult result;
+    do {
+      result = sink.tryEmitNext(value);
+    } while (result.isFailure() && retryHandler.onEmitFailure(SignalType.ON_NEXT, result));
+    return result;
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
@@ -18,7 +18,7 @@ import org.ethereum.beacon.discovery.packet.impl.RawPacketImpl;
 import org.ethereum.beacon.discovery.pipeline.Envelope;
 import org.ethereum.beacon.discovery.pipeline.Field;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Sinks;
 
 class OutgoingParcelHandlerTest {
 
@@ -30,8 +30,8 @@ class OutgoingParcelHandlerTest {
       new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080);
 
   @SuppressWarnings("unchecked")
-  private final FluxSink<NetworkParcel> outgoingSink =
-      (FluxSink<NetworkParcel>) mock(FluxSink.class);
+  private final Sinks.Many<NetworkParcel> outgoingSink =
+      (Sinks.Many<NetworkParcel>) mock(Sinks.Many.class);
 
   private final AddressAccessPolicy addressAccessPolicy =
       address -> !address.equals(DISALLOWED_ADDRESS);
@@ -55,6 +55,6 @@ class OutgoingParcelHandlerTest {
     envelope.put(Field.INCOMING, parcel);
     handler.handle(envelope);
 
-    verify(outgoingSink).next(parcel);
+    verify(outgoingSink).tryEmitNext(parcel);
   }
 }

--- a/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
+++ b/src/test/java/org/ethereum/beacon/discovery/pipeline/handler/OutgoingParcelHandlerTest.java
@@ -4,9 +4,11 @@
 
 package org.ethereum.beacon.discovery.pipeline.handler;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -50,6 +52,7 @@ class OutgoingParcelHandlerTest {
 
   @Test
   void shouldSendPacketsToAllowedHosts() {
+    when(outgoingSink.tryEmitNext(any())).thenReturn(Sinks.EmitResult.OK);
     final Envelope envelope = new Envelope();
     final NetworkParcelV5 parcel = new NetworkParcelV5(PACKET, ALLOWED_ADDRESS);
     envelope.put(Field.INCOMING, parcel);


### PR DESCRIPTION
## Summary

- Bumps Netty 4.1.115.Final → 4.2.15.Final, plus companion upgrades: Guava 33.2→33.6, Log4j 2.23→2.26, BouncyCastle 1.78→1.84, Vert.x 4.5.9→4.5.28, Tuweni 2.7.0→2.7.2
- Adds `org.jspecify:jspecify:1.0.0` (`compileOnly`) to replace `javax.annotation.Nonnull` which was previously provided transitively by Netty 4.1 but dropped in 4.2 (aligns with Besu's migration to JSpecify)
- Resolves all deprecation warnings introduced by these upgrades (Reactor `ReplayProcessor`→`Sinks`, Netty `NioEventLoopGroup`→`MultiThreadIoEventLoopGroup`, `InternetProtocolFamily`→`java.net.StandardProtocolFamily`, Guava `CacheBuilder` duration overload)

## Details

**Netty 4.2 deprecations**
- `NioEventLoopGroup` → `MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())` in `NettyDiscoveryServerImpl`
- `InternetProtocolFamily` → `java.net.StandardProtocolFamily` in `NettyDiscoveryClientImpl`, `DiscoveryManagerImpl`, `DiscoverySystemBuilder`

**Reactor Sinks migration** (`ReplayProcessor`/`FluxProcessor`/`FluxSink` deprecated since Reactor 3.5)
- `ReplayProcessor.cacheLast()` + `FluxSink` → `Sinks.many().replay().latest()` across `NettyDiscoveryServerImpl`, `DiscoveryManagerImpl`, `PipelineImpl`, `SimpleProcessor`, `IncomingMessageSink`, `OutgoingParcelHandler`
- `PipelineImpl.push()` uses `emitNext` with `FAIL_NON_SERIALIZED` retry rather than `tryEmitNext` — necessary because `incomingPipeline` can receive concurrent pushes from IPv4 and IPv6 Netty event-loop threads; the old `ReplayProcessor.FluxSink` serialized these internally, the new safe `Sinks.Many` does not
- `DelegatingReactorScheduler.start()`: suppress deprecated override (preserves delegation behaviour for downstream schedulers)

**Other**
- `CacheBuilder.expireAfterWrite(long, TimeUnit)` → `expireAfterWrite(Duration)` in `ExpirationSet`
- `@Nonnull` → `@NonNull` (JSpecify) in `DelegatingReactorScheduler`, `ErrorHandlingScheduler`

## Test plan

- [ ] `./gradlew build` passes (all 16 integration tests green)
- [ ] `./gradlew compileJava --rerun-tasks` with `-Xlint:deprecation` produces zero deprecation warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UDP discovery I/O and message pipelines with a major Netty bump and changed concurrent emit semantics, though failures are logged and retries are bounded.
> 
> **Overview**
> Upgrades **Netty** (4.1→4.2) and several companion libraries (Guava, Log4j, BouncyCastle, Vert.x, Tuweni), and adds **`org.jspecify`** as `compileOnly` so `@NonNull` replaces `javax.annotation.Nonnull` after Netty dropped that transitively.
> 
> **Netty 4.2 API updates:** discovery servers use `MultiThreadIoEventLoopGroup` + `NioIoHandler` instead of `NioEventLoopGroup`; IPv4/IPv6 channel maps and listen-address validation use `java.net.StandardProtocolFamily` instead of Netty’s `InternetProtocolFamily`.
> 
> **Reactor deprecation cleanup:** `ReplayProcessor` / `FluxSink` paths become `Sinks.many().replay().latest()` (discovery server, manager, pipelines, `SimpleProcessor`, incoming/outgoing handlers). Emits use `tryEmitNext` with logging on failure; **`PipelineImpl.push`** and **`OutgoingParcelHandler`** call new **`Utils.emitNextWithRetry`** to handle `FAIL_NON_SERIALIZED` when multiple event-loop threads push concurrently (behavior the old sink serialized internally). Guava **`ExpirationSet`** switches to `expireAfterWrite(Duration)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def500b497ae765477c9b325e1b49d4bdb8f99f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->